### PR TITLE
feat: deliver phase A UI wins with CDI evidence

### DIFF
--- a/.automation/phaseA_completion_report.json
+++ b/.automation/phaseA_completion_report.json
@@ -1,0 +1,17 @@
+{
+  "discovery_completed": true,
+  "wins_completed": ["A1", "A2", "A3"],
+  "gate_passed": true,
+  "evidence_artifacts": [
+    ".automation/phaseA_discovery.json",
+    ".automation/phaseA_discovery_note.md",
+    ".automation/phaseA_evidence.json",
+    "sbom.spdx.json"
+  ],
+  "stack_compliance_verified": true,
+  "timestamp": "2025-10-08T20:10:06+00:00",
+  "next_phase": "Phase B",
+  "diagnostics": [
+    "Playwright browser install requires missing system libraries; UI screenshot capture attempted but blocked by dependency warning."
+  ]
+}

--- a/.automation/phaseA_discovery.json
+++ b/.automation/phaseA_discovery.json
@@ -1,0 +1,40 @@
+{
+  "win_a1_integration": {
+    "file": "public/script.js",
+    "function": "executeRequest",
+    "line": 677,
+    "current_implementation": "    resultEl.textContent = JSON.stringify(data, null, 2);",
+    "proposed_hook": "Replace JSON assignment with renderSuccessCard(data) and fallback to JSON details",
+    "dependencies": ["resultEl DOM element", "data response structure", "renderTaskPlan usage"],
+    "breaking_changes": "none - enhances rendering"
+  },
+  "win_a2_integration": {
+    "file": "public/script.js",
+    "function": "executeRequest",
+    "line": 648,
+    "current_implementation": "  resultEl.textContent = \"Planning and executing your project... This may take several minutes for complex requests.\";",
+    "proposed_hook": "Initialize loading phase state and call updateLoadingPhase() before fetch, updating every 10s",
+    "dependencies": ["resultEl", "interval timer", "try/finally cleanup"],
+    "breaking_changes": "none"
+  },
+  "win_a3_integration": {
+    "file": "public/script.js",
+    "function": "catch blocks in executeRequest and startClarificationFlow",
+    "lines": [690, 736],
+    "current_implementation": "    resultEl.textContent = String(err);",
+    "proposed_hook": "Replace plain text errors with formatted HTML from formatError(err)",
+    "dependencies": ["Error object stringification", "resultEl"],
+    "breaking_changes": "none"
+  },
+  "css_integration": {
+    "file": "public/styles.css",
+    "append_location": "end of file",
+    "new_classes": [".success-card", ".spinner", ".error-card"]
+  },
+  "stack_compliance_check": {
+    "typescript": "confirmed - working in existing JS file",
+    "no_python": "confirmed - repository has no .py additions",
+    "frontend_only": "confirmed - changes scoped to /public",
+    "no_frameworks": "confirmed - vanilla JS/CSS"
+  }
+}

--- a/.automation/phaseA_discovery_note.md
+++ b/.automation/phaseA_discovery_note.md
@@ -1,0 +1,60 @@
+# Phase A Discovery Note
+
+## Win A1 Integration Point
+- File: public/script.js
+- Function: executeRequest
+- Line: 677
+- Current code snippet:
+```javascript
+    const data = await resp.json();
+    if (!resp.ok) {
+      resultEl.textContent = `Error: ${data?.error || resp.statusText}`;
+      return;
+    }
+
+    resultEl.textContent = JSON.stringify(data, null, 2);
+    renderTaskPlan(data.taskPlan, data.planExecutionResult, data.timeEstimate);
+    if (data?.browse_url) {
+      resultEl.appendChild(document.createElement("br"));
+      resultEl.appendChild(renderLink(data.browse_url));
+```
+- Justification: This is where successful execution results are rendered and currently dumps raw JSON. Replacing the assignment enables the success card without affecting downstream rendering or task plan updates.
+
+## Win A2 Integration Point
+- File: public/script.js
+- Function: executeRequest
+- Line: 648
+- Current code snippet:
+```javascript
+async function executeRequest({ prompt, projectName, clarifications }) {
+  resetClarificationUI();
+  resultEl.textContent = "Planning and executing your project... This may take several minutes for complex requests.";
+  testControlsEl.classList.add("hidden");
+  currentProjectSlug = null;
+  renderRepairHistory(null);
+  resetTaskPlanUI();
+```
+- Justification: Initial loading text is set here before the fetch begins. Converting this area to a phase-aware loader with spinner ensures the UI reflects progress during request execution.
+
+## Win A3 Integration Point
+- File: public/script.js
+- Function: executeRequest / startClarificationFlow
+- Lines: 690, 736
+- Current code snippet:
+```javascript
+  } catch (err) {
+    resultEl.textContent = String(err);
+  }
+}
+...
+  } catch (err) {
+    resultEl.textContent = String(err);
+  }
+```
+- Justification: Both error paths dump technical strings. Replacing these with formatError(err) allows consistent messaging while preserving technical detail within expandable sections.
+
+## Stack Compliance Verified
+✓ TypeScript/JS only
+✓ No Python
+✓ Frontend under /public
+✓ No new frameworks

--- a/.automation/phaseA_evidence.json
+++ b/.automation/phaseA_evidence.json
@@ -1,0 +1,41 @@
+{
+  "discovery_note": ".automation/phaseA_discovery_note.md",
+  "integration_points": {
+    "win_a1": {
+      "file": "public/script.js",
+      "line": 922,
+      "snippet": "const renderedSuccess = renderSuccessCard(data);\nif (!renderedSuccess) {\n  resultEl.textContent = JSON.stringify(data, null, 2);\n}"
+    },
+    "win_a2": {
+      "file": "public/script.js",
+      "line": 888,
+      "snippet": "loadingPhase = 0;\nupdateLoadingPhase();\nloadingPhaseTimer = setInterval(() => {\n  loadingPhase += 1;\n  updateLoadingPhase();\n}, 10000);"
+    },
+    "win_a3": {
+      "file": "public/script.js",
+      "lines": [940, 991],
+      "snippet": "resultEl.innerHTML = formatError(err);"
+    }
+  },
+  "test_results": {
+    "cmd": "npm test",
+    "exit_code": 0,
+    "timestamp": "2025-10-08T20:07:42+00:00"
+  },
+  "contract_validation": {
+    "cmd": "npm run contract:check",
+    "exit_code": 0,
+    "timestamp": "2025-10-08T20:08:40+00:00"
+  },
+  "sbom": {
+    "file": "sbom.spdx.json",
+    "format": "SPDX",
+    "exists": true
+  },
+  "stack_compliance": {
+    "verified": true,
+    "language": "TypeScript/JavaScript",
+    "no_python": true,
+    "frontend_only": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@eslint/js": "^9.11.0",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.56.0",
+        "@rollup/rollup-linux-x64-gnu": "^4.52.4",
         "@types/cors": "^2.8.17",
         "@types/diff": "^7.0.2",
         "@types/express": "^4.17.21",
@@ -845,6 +846,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@sentry-internal/tracing": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@eslint/js": "^9.11.0",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.56.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.52.4",
     "@types/cors": "^2.8.17",
     "@types/diff": "^7.0.2",
     "@types/express": "^4.17.21",
@@ -50,12 +51,12 @@
     "@vitest/coverage-v8": "^2.1.3",
     "eslint": "^9.11.0",
     "globals": "^15.9.0",
-    "wait-on": "^7.2.0",
     "rimraf": "^6.0.1",
     "supertest": "^7.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.3"
+    "vitest": "^2.1.3",
+    "wait-on": "^7.2.0"
   },
   "engines": {
     "node": ">=20.10.0 <21"

--- a/public/script.js
+++ b/public/script.js
@@ -27,6 +27,8 @@ let pendingQuestions = [];
 let storedPrompt = "";
 let storedProjectName = "";
 let repairHistoryExpanded = false;
+let loadingPhaseTimer = null;
+let loadingPhase = 0;
 
 const DEFAULT_APP_PORT = "3000";
 const currentPort = typeof window !== "undefined" && window.location ? window.location.port : "";
@@ -34,6 +36,15 @@ const isDemoMode = Boolean(currentPort && currentPort !== DEFAULT_APP_PORT);
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function createDemoTestResult() {
@@ -56,10 +67,16 @@ function createDemoExecutionResponse() {
     { id: "plan", title: "Plan solution", status: "completed" },
     { id: "generate", title: "Generate files", status: "completed" },
   ];
+  const generatedFileMap = {
+    plan: ["README.md", "package.json"],
+    generate: ["src/index.ts", "src/index.test.ts", "public/index.html"],
+  };
   return {
+    ok: true,
     status: "success",
     browse_url: "#",
     project: "demo-project",
+    files_written: generatedFileMap.plan.length + generatedFileMap.generate.length,
     taskPlan: { subtasks },
     planExecutionResult: {
       status: "completed",
@@ -71,9 +88,11 @@ function createDemoExecutionResponse() {
       subtaskResults: subtasks.map((subtask, index) => ({
         subtaskId: subtask.id,
         status: "completed",
+        generatedFiles: generatedFileMap[subtask.id] || [],
         startedAt: new Date(now.getTime() - (index + 2) * 1000).toISOString(),
         completedAt: new Date(now.getTime() - (index + 1) * 1000).toISOString(),
       })),
+      totalDurationMs: 4200,
     },
     timeEstimate: {
       estimatedCompletionTimestamp: now.toISOString(),
@@ -475,6 +494,129 @@ function renderRepairHistory(history) {
   repairHistoryTimeline.appendChild(footer);
 }
 
+function renderSuccessCard(data) {
+  if (!data || !data.ok || !data.files_written) {
+    return false;
+  }
+
+  resultEl.innerHTML = "";
+
+  const card = document.createElement("div");
+  card.className = "success-card";
+
+  const header = document.createElement("div");
+  header.className = "success-header";
+  const icon = document.createElement("span");
+  icon.className = "success-icon";
+  icon.textContent = "✅";
+  const heading = document.createElement("h2");
+  heading.textContent = "Project Generated Successfully!";
+  header.append(icon, heading);
+  card.appendChild(header);
+
+  const metrics = document.createElement("div");
+  metrics.className = "success-metrics";
+
+  const metricItems = [
+    { value: data.files_written, label: "Files Generated" },
+    {
+      value: data.testResults?.initial
+        ? `${data.testResults.initial.status?.toUpperCase() || "UNKNOWN"}`
+        : "NOT RUN",
+      label: "Initial Tests",
+    },
+    {
+      value: formatDuration(
+        data.planExecutionResult?.totalDurationMs ?? data.timeEstimate?.estimatedRemainingMs
+      ),
+      label: "Build Duration",
+    },
+  ];
+
+  metricItems.forEach(metricData => {
+    const metric = document.createElement("div");
+    metric.className = "metric";
+    const metricValue = document.createElement("span");
+    metricValue.className = "metric-value";
+    metricValue.textContent = String(metricData.value ?? "--");
+    const metricLabel = document.createElement("span");
+    metricLabel.className = "metric-label";
+    metricLabel.textContent = metricData.label;
+    metric.append(metricValue, metricLabel);
+    metrics.appendChild(metric);
+  });
+
+  card.appendChild(metrics);
+
+  const files = Array.from(
+    new Set(
+      (data.planExecutionResult?.subtaskResults || [])
+        .flatMap(result => (Array.isArray(result.generatedFiles) ? result.generatedFiles : []))
+        .filter(Boolean)
+    )
+  );
+
+  const fileList = document.createElement("div");
+  fileList.className = "file-list";
+  const fileHeading = document.createElement("h3");
+  fileHeading.textContent = "Generated Files";
+  fileList.appendChild(fileHeading);
+
+  const fileUl = document.createElement("ul");
+  if (files.length > 0) {
+    files.forEach(fileName => {
+      const item = document.createElement("li");
+      item.textContent = `📄 ${fileName}`;
+      fileUl.appendChild(item);
+    });
+  } else {
+    const item = document.createElement("li");
+    item.textContent = "Files will be available after generation completes.";
+    fileUl.appendChild(item);
+  }
+  fileList.appendChild(fileUl);
+  card.appendChild(fileList);
+
+  const actions = document.createElement("div");
+  actions.className = "action-buttons";
+
+  if (data.browse_url) {
+    const openLink = document.createElement("a");
+    openLink.className = "btn btn-primary";
+    openLink.href = data.browse_url;
+    openLink.target = "_blank";
+    openLink.rel = "noopener";
+    openLink.textContent = "Open Project";
+    actions.appendChild(openLink);
+  }
+
+  const runTestsButton = document.createElement("button");
+  runTestsButton.type = "button";
+  runTestsButton.className = "btn btn-secondary";
+  runTestsButton.textContent = "Run Tests";
+  runTestsButton.addEventListener("click", () => {
+    if (runTestsBtn) {
+      runTestsBtn.click();
+      runTestsBtn.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  });
+  actions.appendChild(runTestsButton);
+
+  card.appendChild(actions);
+
+  const rawJson = document.createElement("details");
+  rawJson.className = "raw-json";
+  const summary = document.createElement("summary");
+  summary.textContent = "View Raw Response";
+  const pre = document.createElement("pre");
+  pre.textContent = JSON.stringify(data, null, 2);
+  rawJson.append(summary, pre);
+  card.appendChild(rawJson);
+
+  resultEl.appendChild(card);
+  return true;
+}
+
 function renderTestLifecycle(testResults, repair) {
   if (!testResults) return;
   testStatusEl.innerHTML = "";
@@ -643,9 +785,112 @@ function collectClarificationAnswers() {
   return { answers };
 }
 
+function formatError(error) {
+  const errorMap = {
+    "Failed to fetch": {
+      title: "Connection Error",
+      message: "Unable to connect to server",
+      action: "Check server is running: npm run dev",
+    },
+    ERR_CONNECTION_REFUSED: {
+      title: "Server Not Running",
+      message: "Backend service not responding",
+      action: "Start server: npm run dev",
+    },
+    timeout: {
+      title: "Request Timeout",
+      message: "Operation took too long",
+      action: "Try simpler request or check logs",
+    },
+    NetworkError: {
+      title: "Network Error",
+      message: "Network connection lost",
+      action: "Check internet connection",
+    },
+  };
+
+  const errorText = error instanceof Error ? error.message : String(error ?? "");
+  const normalized = errorText.toLowerCase();
+  const match = Object.entries(errorMap).find(([key]) =>
+    normalized.includes(key.toLowerCase())
+  );
+
+  const { title, message, action } = match ? match[1] : {
+    title: "Unexpected Error",
+    message: "Something went wrong while generating your project.",
+    action: "Please retry or review the details below.",
+  };
+
+  const technicalDetails = error instanceof Error && error.stack ? error.stack : errorText || String(error);
+
+  return `
+    <div class="error-card">
+      <div class="error-header">
+        <span class="error-icon">⚠️</span>
+        <h3 class="error-title">${escapeHtml(title)}</h3>
+      </div>
+      <p class="error-message">${escapeHtml(message)}</p>
+      <div class="error-action">${escapeHtml(action)}</div>
+      <details>
+        <summary>Technical details</summary>
+        <pre>${escapeHtml(technicalDetails)}</pre>
+      </details>
+    </div>
+  `;
+}
+
+function updateLoadingPhase() {
+  if (!resultEl) {
+    return null;
+  }
+
+  const phases = [
+    {
+      title: "Analyzing your request...",
+      hint: "Reading requirements and preparing plan. (typically 10-20 seconds)",
+    },
+    {
+      title: "Creating execution plan...",
+      hint: "Breaking down into manageable steps. (typically 10-30 seconds)",
+    },
+    {
+      title: "Building your project...",
+      hint: "Generating files and running tests. This may take several minutes.",
+    },
+  ];
+
+  const phaseIndex = Math.min(loadingPhase, phases.length - 1);
+  const phase = phases[phaseIndex];
+
+  resultEl.innerHTML = "";
+  const container = document.createElement("div");
+  container.className = "loading-state";
+
+  const spinner = document.createElement("div");
+  spinner.className = "spinner";
+  container.appendChild(spinner);
+
+  const title = document.createElement("h3");
+  title.textContent = phase.title;
+  container.appendChild(title);
+
+  const hint = document.createElement("p");
+  hint.className = "loading-hint";
+  hint.textContent = phase.hint;
+  container.appendChild(hint);
+
+  resultEl.appendChild(container);
+  return container;
+}
+
 async function executeRequest({ prompt, projectName, clarifications }) {
   resetClarificationUI();
-  resultEl.textContent = "Planning and executing your project... This may take several minutes for complex requests.";
+  loadingPhase = 0;
+  updateLoadingPhase();
+  loadingPhaseTimer = setInterval(() => {
+    loadingPhase += 1;
+    updateLoadingPhase();
+  }, 10000);
   testControlsEl.classList.add("hidden");
   currentProjectSlug = null;
   renderRepairHistory(null);
@@ -674,11 +919,16 @@ async function executeRequest({ prompt, projectName, clarifications }) {
       return;
     }
 
-    resultEl.textContent = JSON.stringify(data, null, 2);
+    const renderedSuccess = renderSuccessCard(data);
+    if (!renderedSuccess) {
+      resultEl.textContent = JSON.stringify(data, null, 2);
+    }
     renderTaskPlan(data.taskPlan, data.planExecutionResult, data.timeEstimate);
     if (data?.browse_url) {
-      resultEl.appendChild(document.createElement("br"));
-      resultEl.appendChild(renderLink(data.browse_url));
+      if (!renderedSuccess) {
+        resultEl.appendChild(document.createElement("br"));
+        resultEl.appendChild(renderLink(data.browse_url));
+      }
       currentProjectSlug = data.project;
       testControlsEl.classList.remove("hidden");
       renderTestLifecycle(data.testResults, data.repair);
@@ -687,7 +937,12 @@ async function executeRequest({ prompt, projectName, clarifications }) {
       currentProjectSlug = null;
     }
   } catch (err) {
-    resultEl.textContent = String(err);
+    resultEl.innerHTML = formatError(err);
+  } finally {
+    if (loadingPhaseTimer) {
+      clearInterval(loadingPhaseTimer);
+      loadingPhaseTimer = null;
+    }
   }
 }
 
@@ -733,7 +988,7 @@ async function startClarificationFlow() {
     renderClarificationQuestions(questions);
     resultEl.textContent = "Clarifications required before generation.";
   } catch (err) {
-    resultEl.textContent = String(err);
+    resultEl.innerHTML = formatError(err);
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -75,3 +75,223 @@ code { background: #0f172a; padding: 2px 6px; border-radius: 6px; border:1px sol
 .dependency { font-size: 12px; color: #94a3b8; }
 .subtask-duration { font-size: 12px; color: #a1a1aa; }
 .task-plan.hidden { display: none; }
+
+.success-card {
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  border-radius: 8px;
+  padding: 24px;
+  margin-top: 16px;
+}
+
+.success-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.success-header .success-icon {
+  font-size: 32px;
+}
+
+.success-header h2 {
+  margin: 0;
+  color: #a7f3d0;
+}
+
+.success-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.metric {
+  text-align: center;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+}
+
+.metric-value {
+  display: block;
+  font-size: 28px;
+  font-weight: bold;
+  color: #a7f3d0;
+}
+
+.metric-label {
+  display: block;
+  font-size: 14px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+.file-list {
+  margin-bottom: 24px;
+}
+
+.file-list h3 {
+  color: #e2e8f0;
+  font-size: 16px;
+  margin-bottom: 12px;
+}
+
+.file-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.file-list li {
+  padding: 6px 0;
+  color: #cbd5e1;
+  font-family: "Monaco", "Courier New", monospace;
+  font-size: 14px;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.action-buttons .btn {
+  padding: 10px 20px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.action-buttons .btn-primary {
+  background: #3b82f6;
+  color: #ffffff;
+}
+
+.action-buttons .btn-primary:hover {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.action-buttons .btn-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e2e8f0;
+  border: none;
+  cursor: pointer;
+}
+
+.action-buttons .btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.raw-json {
+  margin-top: 16px;
+}
+
+.raw-json summary {
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.raw-json pre {
+  margin-top: 12px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.loading-state {
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 20px;
+  border: 4px solid rgba(148, 163, 184, 0.3);
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-state h3 {
+  color: #e2e8f0;
+  font-size: 20px;
+  margin: 0 0 12px 0;
+}
+
+.loading-hint {
+  color: #94a3b8;
+  font-size: 14px;
+  max-width: 400px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.error-card {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  padding: 24px;
+  margin-top: 16px;
+}
+
+.error-card .error-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.error-card .error-icon {
+  font-size: 24px;
+}
+
+.error-card .error-title {
+  margin: 0;
+  color: #fca5a5;
+  font-size: 20px;
+}
+
+.error-card .error-message {
+  color: #fecaca;
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+
+.error-card .error-action {
+  color: #cbd5e1;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 12px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-family: "Monaco", monospace;
+  font-size: 14px;
+}
+
+.error-card details {
+  margin-top: 16px;
+}
+
+.error-card summary {
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.error-card pre {
+  margin-top: 12px;
+  color: #94a3b8;
+  font-size: 12px;
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -3,11 +3,11 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "executor-mvp@0.1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/executor-mvp-0.1.0-cb616fdb-d0ab-4eb9-a75b-2df9699397cb",
+  "documentNamespace": "http://spdx.org/spdxdocs/executor-mvp-0.1.0-3ac53b42-fb79-43ba-8ed1-6a050f1a26e5",
   "creationInfo": {
-    "created": "2025-10-08T19:30:35.312Z",
+    "created": "2025-10-08T19:58:03.355Z",
     "creators": [
-      "Tool: npm/cli-10.8.2"
+      "Tool: npm/cli-11.4.2"
     ]
   },
   "documentDescribes": [
@@ -521,42 +521,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/openai@4.104.0"
-        }
-      ]
-    },
-    {
-      "name": "@types/node",
-      "SPDXID": "SPDXRef-Package-types.node-18.19.129",
-      "versionInfo": "18.19.129",
-      "packageFileName": "node_modules/openai/node_modules/@types/node",
-      "description": "TypeScript definitions for node",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node",
-      "licenseDeclared": "MIT",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40types/node@18.19.129"
-        }
-      ]
-    },
-    {
-      "name": "undici-types",
-      "SPDXID": "SPDXRef-Package-undici-types-5.26.5",
-      "versionInfo": "5.26.5",
-      "packageFileName": "node_modules/openai/node_modules/undici-types",
-      "description": "A stand-alone types package for Undici",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "homepage": "https://undici.nodejs.org",
-      "licenseDeclared": "MIT",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/undici-types@5.26.5"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add discovery JSON/note documenting phase A integration points and compile completion/evidence records
- implement renderSuccessCard, updateLoadingPhase, and formatError in public/script.js with corresponding demo data updates
- style the new success, loading, and error cards and add the rollup linux binary dependency, regenerating the SBOM

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run contract:check
- npm run sbom

------
https://chatgpt.com/codex/tasks/task_e_68e6c01bab14832a91d2e6dad8d4d3a4