### PR TITLE
Implement step queue checkpointing for WA61

### DIFF
--- a/.automation/phaseE_hardening_discovery.json
+++ b/.automation/phaseE_hardening_discovery.json
@@ -1,0 +1,50 @@
+{
+  "phase": "E Hardening — Pause/Resume",
+  "task": "D60",
+  "date": "2025-10-11",
+  "objective": "Document current pause/resume integration points across backend orchestration, frontend UX, and dependency policy before refactoring.",
+  "integration_points": [
+    {
+      "file": "src/server.ts",
+      "line_hint": 1145,
+      "summary": "POST /api/execute orchestrates plan + single execution with PausedError handling but no step-level jobs."
+    },
+    {
+      "file": "src/server.ts",
+      "line_hint": 1586,
+      "summary": "Resume endpoint reloads checkpoint then submits a single execution job without awaiting or step metadata."
+    },
+    {
+      "file": "src/llm/index.ts",
+      "line_hint": 53,
+      "summary": "generateJSON supports AbortSignal but callers never pass session-aware signals."
+    },
+    {
+      "file": "src/runner/runInSandbox.ts",
+      "line_hint": 43,
+      "summary": "Sandbox tests only check abort before spawn; child process lacks pause-aware termination."
+    },
+    {
+      "file": "public/script.js",
+      "line_hint": 220,
+      "summary": "Frontend treats 202 as paused but keeps polling indefinitely and lacks step context."
+    },
+    {
+      "file": "src/runner/installDeps.ts",
+      "line_hint": 39,
+      "summary": "Dependency preflight still throws for registry validation failures, blocking resume flows."
+    }
+  ],
+  "risks": [
+    "Pause requests rely on coarse monolithic jobs, so resume restarts large chunks of work.",
+    "Abort signals are not propagated into LLM or sandbox processes, leading to long pause latencies.",
+    "Frontend polling may conflict with future SSE-driven step updates during paused states.",
+    "Dependency validation can still fail hard even when npm install would succeed."
+  ],
+  "next_steps": [
+    "Design BullMQ-compatible step queue API and checkpoint payload schema (WA61).",
+    "Propagate AbortSignal through LLM providers and sandbox subprocess lifecycle (WA63/WA64).",
+    "Define paused-state UX updates and polling/SSE coordination (WA65).",
+    "Relax dependency preflight errors into structured warnings (WA66)."
+  ]
+}

--- a/.automation/phaseE_hardening_discovery_note.md
+++ b/.automation/phaseE_hardening_discovery_note.md
@@ -1,0 +1,181 @@
+# Phase E Hardening — Discovery Note (Task D60)
+
+## Scope & Compliance Check
+- **Contract**: `contracts/Roadmap_execution/15_Phase_E_Hardening.json` — task D60 requires mapping pause/resume integration points before modifying code.
+- **Stack**: Backend TypeScript/Express and vanilla JS frontend; matches `ai-stack.json` requirements. No prohibited tech observed during discovery.
+
+## Integration Points & Current Behavior
+
+### 1. `/api/execute` orchestration entrypoint
+```ts
+// src/server.ts L1145-L1337
+app.post("/api/execute", async (req, res) => {
+  const sessionId: string | undefined = typeof req.body?.sessionId === 'string' ? req.body.sessionId : undefined;
+  try {
+    if (sessionId) {
+      createAbortSignal(sessionId);
+    }
+    setProgress(sessionId, "analyzing", 10);
+    ...
+    if (isComplexPrompt(effectivePrompt, clarifications)) {
+      try {
+        throwIfAborted(sessionId, "decomposition");
+        const planJob = createPlanJobPayload({ ... , sessionId });
+        const planResultJob = await executionQueue.submit(planJob);
+        ...
+      } catch (planError) {
+        if (planError instanceof PausedError) {
+          throw planError;
+        }
+        // falls back to single execution
+      }
+    }
+    const singleJob = createSingleJobPayload(singleOptions);
+    const resultJob = await executionQueue.submit(singleJob);
+    ...
+  } catch (err: unknown) {
+    if (err instanceof PausedError) {
+      cleanupAbortSignal(sessionId);
+      return res.status(202).json({ paused: true, sessionId: err.sessionId, phase: err.phase, message: err.message });
+    }
+    cleanupAbortSignal(sessionId);
+    return res.status(500).json({ error: message });
+  } finally {
+    cleanupAbortSignal(sessionId);
+  }
+});
+```
+- Planning and generation still execute as monolithic jobs that only checkpoint at pause boundaries; a fallback to single execution resets the state machine instead of breaking work into resumable steps.
+- `generateJSON` is invoked later in `generateExecutorOutputFromPrompt` without an abort signal, so LLM work keeps running after `PausedError` is thrown elsewhere.
+
+### 2. Resume endpoint and queue re-entry
+```ts
+// src/server.ts L1586-L1725
+app.post("/api/sessions/:id/resume", async (req, res) => {
+  const session = getOrchestrationSession(sessionId);
+  const result = await resumeFromCheckpoint(sessionId, answers, { machine: session.machine, reason: reasonRaw || undefined });
+  session.machine = result.machine;
+  ...
+  if (providerConfigured) {
+    createAbortSignal(sessionId);
+    const resumeOptions: SingleExecutionOptions = { sessionId, preserveWorkspace: true, slugOverride: projectSlug, ... };
+    if (executionQueue.mode === "bullmq") {
+      setProgress(sessionId, "planning", 20, queuedMeta);
+    }
+    executionQueue
+      .submit(createSingleJobPayload(resumeOptions))
+      .catch(error => {
+        if (error instanceof PausedError) { return; }
+        setProgress(sessionId, "finalizing", 100, { resume: true, error: message }, true);
+        cleanupAbortSignal(sessionId);
+      });
+  }
+  return res.json({ checkpoint: result.checkpoint, answeredQuestions: result.answeredQuestions, resumed: true });
+});
+```
+- Resume loads the checkpoint and immediately submits a **single execution job**; there is no concept of replaying the specific unfinished step. In inline mode this promise runs synchronously but is intentionally not awaited, leaving no guarantee that orchestration advances after the response.
+- The API never returns metadata about the next step to run, so the client cannot reflect which phase will resume.
+
+### 3. Abort propagation gaps
+```ts
+// src/server.ts L432-L470
+async function generateExecutorOutputFromPrompt(...) {
+  throwIfAborted(sessionId, "code_generation");
+  const messages = [...];
+  const raw = await withTraceContext({ phase: 'single' }, async () => generateJSON(messages));
+  ...
+}
+```
+```ts
+// src/llm/index.ts L53-L110
+export async function generateJSON(messages: LLMMessage[], options: GenerateJSONOptions = {}): Promise<string> {
+  const provider = chooseProvider();
+  const runProviderCall = async (...) =>
+    Promise.race([
+      provider.generate(inputMessages, { tools: providerTools, signal: options.signal }),
+      new Promise<ProviderGenerateResult>((_, rej) => setTimeout(...))
+    ]);
+  ...
+}
+```
+```ts
+// src/runner/runInSandbox.ts L43-L126
+export async function runInSandbox(options: RunInSandboxOptions): Promise<RunResult> {
+  const { projectRoot, projectSlug, command: providedCommand, timeoutMs = DEFAULT_TIMEOUT_MS, sessionId } = options;
+  throwIfAborted(sessionId, "testing");
+  ...
+  const child = spawn(command, { cwd: projectRoot, ... });
+  ...
+  const { code, signal } = await exitPromise.finally(() => {
+    clearTimeout(timeoutHandle);
+    logStream.end();
+  });
+}
+```
+- Abort checks happen **before** LLM or sandbox work starts, but there is no `AbortSignal` passed into `generateJSON`, and spawned child processes have no pause-aware signal handling. Once a pause request arrives, ongoing work continues until natural completion.
+
+### 4. Frontend pause handling & UX contract
+```js
+// public/script.js L220-L241, L1300-L1386
+async function handlePausedResponse(sessionId) {
+  const snapshotResp = await fetch(`/api/progress/snapshot/${sessionId}`);
+  if (snapshotResp.ok) {
+    const snapshot = await snapshotResp.json();
+    updateOrchestrationState(snapshot);
+    return true;
+  }
+  return false;
+}
+...
+async function executeRequest({ prompt, projectName, clarifications }) {
+  const sessionId = ...;
+  ...
+  const resp = await fetch("/api/execute", { method: "POST", body: JSON.stringify(payload) });
+  if (resp.status === 202) {
+    await resp.json().catch(() => ({}));
+    await handlePausedResponse(sessionId);
+    return;
+  }
+  const data = await resp.json();
+  if (!resp.ok) {
+    renderErrorCard({ error: data?.error || resp.statusText });
+    return;
+  }
+  ...
+}
+```
+- The UI now treats `202 Accepted` as a paused state and fetches a snapshot immediately, but progress polling continues indefinitely because `stopPolling` never toggles for paused states. Resume actions depend on background polling recognizing the session’s completion.
+- `updateOrchestrationState` disables the pause button when paused but there is no persistent state for step IDs or manifests that a resumed job would need.
+
+### 5. Dependency preflight strictness
+```ts
+// src/runner/installDeps.ts L39-L109
+await validateDependencies(pkg.dependencies, pkg.devDependencies, {
+  allowDeprecated: true,
+  allowVersionMismatch: true
+});
+...
+if (!offlineRegistryFailure) {
+  throw err;
+}
+```
+- Dependency validation is invoked on every resume/test run. It permits deprecated packages and version mismatches, but **still throws** when registry lookups fail for reasons other than connectivity, halting resume flows even when npm would succeed.
+
+## Observations & Risks
+1. **Monolithic jobs**: Pause interruptions force a fallback to single execution, making resumptions restart the entire generation rather than continuing at the last completed step.
+2. **Abort propagation**: LLM and sandbox workers ignore pause signals mid-flight, so users observe long delays between triggering pause and seeing work stop.
+3. **Resume re-entry**: Resume submits a single job without awaiting completion or tracking step metadata, so multiple resume requests can stack, and inline mode provides no guarantee the orchestration loop restarts.
+4. **Frontend timing**: Polling loops stay active during pause, which can conflict with future plans to rely on SSE step events.
+5. **Validation gating**: Dependency preflight can still abort runs when npm could resolve issues, contradicting the contract’s request to downgrade to warnings.
+
+## Open Questions / Follow-ups
+- What granularity should the new step queue expose to align with checkpoint payloads (e.g., per subtask, per repair attempt)?
+- Should pause responses include the last persisted step identifier so the client can render more context?
+- What telemetry schema additions are required for `.automation/execution_trace.jsonl` to capture pause/resume lifecycle events?
+
+## Recommended Next Steps (per contract)
+1. Design step-level queue APIs and checkpoint payload structure before touching implementation (`WA61`).
+2. Define abort propagation strategy for LLM providers and sandbox processes (`WA63`, `WA64`).
+3. Draft frontend state diagram for paused/resumed UI to ensure polling vs SSE is coordinated (`WA65`).
+4. Update dependency validation options to emit warnings instead of throwing on mismatches (`WA66`).
+

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,6 +3,7 @@ import { logEvent } from "../telemetry/events.js";
 import { getTraceContext } from "./trace.js";
 import { writeFixture } from "../fixtures/index.js";
 import { DEFAULT_FS_TOOLS } from "./tools/fsTools.js";
+import { getAbortSignal, throwIfAborted, PausedError } from "../orchestrator/abortSignal.js";
 import type {
   GenerateJSONOptions,
   LLMMessage,
@@ -43,6 +44,30 @@ function mapToolSchemas(tools: ToolDefinition[]): ToolDefinition[] {
   return tools;
 }
 
+function combineAbortSignals(...signals: (AbortSignal | undefined)[]): AbortSignal | undefined {
+  const active = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (active.length === 0) {
+    return undefined;
+  }
+  if (active.length === 1) {
+    return active[0];
+  }
+  const controller = new AbortController();
+  const abort = (reason?: unknown) => {
+    if (!controller.signal.aborted) {
+      controller.abort(reason);
+    }
+  };
+  for (const signal of active) {
+    if (signal.aborted) {
+      abort(signal.reason);
+    } else {
+      signal.addEventListener("abort", () => abort(signal.reason), { once: true });
+    }
+  }
+  return controller.signal;
+}
+
 async function executeToolCall(
   tool: ToolDefinition,
   call: LLMToolCall,
@@ -71,6 +96,16 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
   let attempt = 0;
   for (;;) {
     const traceContext = getTraceContext();
+    const sessionId = options.sessionId ?? traceContext?.sessionId;
+    const phase = traceContext?.phase ?? "llm";
+    const sessionAbortSignal = options.abortSignal ?? (sessionId ? getAbortSignal(sessionId) : undefined);
+    const externalSignal = options.signal && options.signal !== sessionAbortSignal ? options.signal : undefined;
+    const combinedAbortSignal = combineAbortSignals(sessionAbortSignal, externalSignal);
+
+    if (sessionId) {
+      throwIfAborted(sessionId, phase);
+    }
+
     const tools = resolveTools(options, traceContext);
     const toolContext = normalizeToolContext(options, traceContext);
     const providerTools = tools.length
@@ -84,18 +119,55 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
     const executedTools: Array<{ name: string; arguments: unknown; result: unknown; callId: string }> = [];
     const conversation = toProviderMessages(messages);
 
-    const runProviderCall = async (inputMessages: LLMRequestMessage[]): Promise<ProviderGenerateResult> =>
-      Promise.race([
-        provider.generate(inputMessages, { tools: providerTools, signal: options.signal }),
-        new Promise<ProviderGenerateResult>((_, rej) =>
-          setTimeout(() => rej(new Error(`LLM call timed out after ${callTimeout}ms`)), callTimeout)
-        )
-      ]);
+    const runProviderCall = async (inputMessages: LLMRequestMessage[]): Promise<ProviderGenerateResult> => {
+      const timeoutController = new AbortController();
+      const signal = combineAbortSignals(timeoutController.signal, combinedAbortSignal) ?? timeoutController.signal;
+      const timeoutHandle = setTimeout(() => {
+        timeoutController.abort(new Error(`LLM call timed out after ${callTimeout}ms`));
+      }, callTimeout);
+      const maybeTimer = timeoutHandle as unknown as { unref?: () => void };
+      maybeTimer.unref?.();
+
+      try {
+        const response = await provider.generate(inputMessages, {
+          tools: providerTools,
+          signal,
+          onToken: options.onToken
+        });
+        if (sessionId) {
+          throwIfAborted(sessionId, phase);
+        }
+        return response;
+      } catch (error) {
+        if (error instanceof PausedError) {
+          throw error;
+        }
+        if (timeoutController.signal.aborted) {
+          const reason = timeoutController.signal.reason;
+          if (reason instanceof Error) {
+            throw reason;
+          }
+          throw new Error(`LLM call timed out after ${callTimeout}ms`);
+        }
+        if (sessionAbortSignal?.aborted && sessionId) {
+          throw new PausedError(sessionId, phase);
+        }
+        if (combinedAbortSignal?.aborted && sessionId) {
+          throw new PausedError(sessionId, phase);
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutHandle);
+      }
+    };
 
     try {
       let response: ProviderGenerateResult | null = null;
       for (let depth = 0; depth <= maxToolIterations; depth += 1) {
         response = await runProviderCall(conversation);
+        if (sessionId) {
+          throwIfAborted(sessionId, phase);
+        }
         if (response.toolCalls && response.toolCalls.length > 0 && tools.length > 0) {
           const toolMessage: LLMRequestMessage = {
             role: "assistant",
@@ -108,7 +180,13 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
             if (!tool) {
               throw new Error(`Unknown tool requested: ${call.name}`);
             }
+            if (sessionId) {
+              throwIfAborted(sessionId, `${phase}_tool_${call.name}`);
+            }
             const { result, parsedArgs } = await executeToolCall(tool, call, toolContext);
+            if (sessionId) {
+              throwIfAborted(sessionId, `${phase}_tool_${call.name}`);
+            }
             executedTools.push({ name: tool.name, arguments: parsedArgs, result, callId: call.id });
             conversation.push({
               role: "tool",
@@ -132,6 +210,9 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
       }
 
       try {
+        if (sessionId) {
+          throwIfAborted(sessionId, phase);
+        }
         if (traceContext?.sessionId && traceContext.projectSlug) {
           const ts = new Date().toISOString().replace(/[:.]/g, "-");
           const nameParts = [ts, traceContext.phase || "llm", traceContext.subtaskId || ""].filter(Boolean).join("_");
@@ -144,7 +225,7 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
             response: content,
             tools: executedTools.length ? executedTools : undefined
           };
-          await writeFixture(traceContext.projectSlug, traceContext.sessionId, relPath, payload);
+          await writeFixture(traceContext.projectSlug, traceContext.sessionId!, relPath, payload);
         }
       } catch {
         // best-effort only
@@ -152,6 +233,9 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
 
       return content;
     } catch (err: unknown) {
+      if (err instanceof PausedError) {
+        throw err;
+      }
       const e = err as { status?: number; code?: string; message?: string };
       const status = e?.status ?? 0;
       const code = e?.code ?? "";
@@ -184,3 +268,4 @@ export async function generateJSON(messages: LLMMessage[], options: GenerateJSON
     }
   }
 }
+

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -38,10 +38,13 @@ export class AnthropicProvider {
       max_tokens: 4096,
       temperature: 0.2,
       messages: conversation
-    });
+    }, { signal: options.signal });
     const content = resp.content?.[0];
     if (content?.type !== "text") {
       throw new Error("Anthropic response missing text content");
+    }
+    if (options.onToken) {
+      options.onToken(content.text);
     }
     return { content: content.text, toolCalls: undefined };
   }

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -125,6 +125,10 @@ export class OpenAIProvider {
 
     const content = normalizeContent(message.content);
 
+    if (typeof content === "string" && options.onToken) {
+      options.onToken(content);
+    }
+
     return { content, toolCalls };
   }
 }

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -33,6 +33,7 @@ export type LLMRequestMessage =
 export interface ProviderGenerateOptions {
   tools?: ProviderToolSchema[];
   signal?: AbortSignal;
+  onToken?: (chunk: string) => void;
 }
 
 export interface ProviderGenerateResult {
@@ -46,4 +47,6 @@ export interface GenerateJSONOptions {
   toolContext?: ToolExecutionContext;
   maxToolIterations?: number;
   signal?: AbortSignal;
+  abortSignal?: AbortSignal;
+  onToken?: (chunk: string) => void;
 }

--- a/src/orchestrator/abortSignal.ts
+++ b/src/orchestrator/abortSignal.ts
@@ -17,6 +17,10 @@ export class PausedError extends Error {
     super(message || `Execution paused during ${phase}`);
     this.name = "PausedError";
   }
+
+  stepId?: string;
+  stepType?: string;
+  sequence?: number;
 }
 
 interface AbortEntry {

--- a/src/orchestrator/checkpointStore.ts
+++ b/src/orchestrator/checkpointStore.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { randomUUID } from "node:crypto";
+
+export type StepStatus = "queued" | "running" | "completed" | "skipped" | "failed" | "paused";
+
+export interface StepRecord {
+  stepId: string;
+  stepType: string;
+  sequence: number;
+  status: StepStatus;
+  queuedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  payload?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  error?: { message: string; stack?: string };
+  stop?: boolean;
+}
+
+export interface StepWorkflow {
+  sessionId: string;
+  cursor: number;
+  steps: StepRecord[];
+  updatedAt: string;
+}
+
+interface StepQueuedInput {
+  sessionId: string;
+  stepId?: string;
+  stepType: string;
+  sequence: number;
+  payload?: Record<string, unknown>;
+}
+
+interface StepCompletionInput {
+  sessionId: string;
+  stepId: string;
+  status: Extract<StepStatus, "completed" | "skipped">;
+  result?: Record<string, unknown>;
+  stop?: boolean;
+}
+
+interface StepFailureInput {
+  sessionId: string;
+  stepId: string;
+  error: unknown;
+}
+
+const WORKFLOW_ROOT = path.resolve(".automation", "checkpoints", "step-workflows");
+
+function sanitizeSessionId(sessionId: string): string {
+  const trimmed = sessionId.trim();
+  if (!trimmed) {
+    throw new Error("sessionId is required for checkpoint operations");
+  }
+  if (trimmed.includes("..") || trimmed.includes(path.sep)) {
+    throw new Error("sessionId contains invalid characters");
+  }
+  return trimmed;
+}
+
+async function ensureRoot(): Promise<void> {
+  await fs.mkdir(WORKFLOW_ROOT, { recursive: true });
+}
+
+function cloneValue<T>(value: T): T {
+  if (value === undefined) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function readWorkflow(sessionId: string): Promise<StepWorkflow | null> {
+  const safeId = sanitizeSessionId(sessionId);
+  const filePath = path.join(WORKFLOW_ROOT, `${safeId}.json`);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(raw) as StepWorkflow;
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeWorkflow(workflow: StepWorkflow): Promise<void> {
+  await ensureRoot();
+  const safeId = sanitizeSessionId(workflow.sessionId);
+  const filePath = path.join(WORKFLOW_ROOT, `${safeId}.json`);
+  const payload = JSON.stringify(workflow, null, 2);
+  await fs.writeFile(filePath, payload, "utf-8");
+}
+
+function upsertStep(workflow: StepWorkflow, record: StepRecord): StepWorkflow {
+  const steps = workflow.steps.slice();
+  const index = steps.findIndex(entry => entry.stepId === record.stepId);
+  if (index >= 0) {
+    steps[index] = { ...steps[index], ...record };
+  } else {
+    steps.push(record);
+  }
+  const cursor = Math.max(workflow.cursor, record.sequence);
+  const updatedAt = new Date().toISOString();
+  return { sessionId: workflow.sessionId, cursor, steps, updatedAt };
+}
+
+export async function resetWorkflow(sessionId: string): Promise<void> {
+  const safeId = sanitizeSessionId(sessionId);
+  const filePath = path.join(WORKFLOW_ROOT, `${safeId}.json`);
+  await ensureRoot();
+  await fs.rm(filePath, { force: true });
+}
+
+export async function loadWorkflow(sessionId: string): Promise<StepWorkflow | null> {
+  await ensureRoot();
+  return readWorkflow(sessionId);
+}
+
+export async function recordStepQueued(input: StepQueuedInput): Promise<StepRecord> {
+  await ensureRoot();
+  const sessionId = sanitizeSessionId(input.sessionId);
+  const workflow = (await readWorkflow(sessionId)) ?? {
+    sessionId,
+    cursor: -1,
+    steps: [],
+    updatedAt: new Date().toISOString()
+  };
+
+  const stepId = input.stepId ?? randomUUID();
+  const record: StepRecord = {
+    stepId,
+    stepType: input.stepType,
+    sequence: input.sequence,
+    status: "queued",
+    queuedAt: new Date().toISOString(),
+    payload: cloneValue(input.payload)
+  };
+
+  const next = upsertStep(workflow, record);
+  await writeWorkflow(next);
+  return record;
+}
+
+export async function recordStepRunning(sessionId: string, stepId: string): Promise<void> {
+  const workflow = await readWorkflow(sessionId);
+  if (!workflow) {
+    throw new Error(`Workflow not initialized for session ${sessionId}`);
+  }
+  const step = workflow.steps.find(entry => entry.stepId === stepId);
+  if (!step) {
+    throw new Error(`Unknown step ${stepId} for session ${sessionId}`);
+  }
+  const updated: StepRecord = {
+    ...step,
+    status: "running",
+    startedAt: new Date().toISOString(),
+    error: undefined
+  };
+  const next = upsertStep(workflow, updated);
+  await writeWorkflow(next);
+}
+
+export async function recordStepCompletion(input: StepCompletionInput): Promise<void> {
+  const workflow = await readWorkflow(input.sessionId);
+  if (!workflow) {
+    throw new Error(`Workflow not initialized for session ${input.sessionId}`);
+  }
+  const step = workflow.steps.find(entry => entry.stepId === input.stepId);
+  if (!step) {
+    throw new Error(`Unknown step ${input.stepId} for session ${input.sessionId}`);
+  }
+  const updated: StepRecord = {
+    ...step,
+    status: input.status,
+    completedAt: new Date().toISOString(),
+    result: cloneValue(input.result),
+    stop: Boolean(input.stop),
+    error: undefined
+  };
+  const next = upsertStep(workflow, updated);
+  await writeWorkflow(next);
+}
+
+export async function recordStepFailure(input: StepFailureInput): Promise<void> {
+  const workflow = await readWorkflow(input.sessionId);
+  if (!workflow) {
+    throw new Error(`Workflow not initialized for session ${input.sessionId}`);
+  }
+  const step = workflow.steps.find(entry => entry.stepId === input.stepId);
+  if (!step) {
+    throw new Error(`Unknown step ${input.stepId} for session ${input.sessionId}`);
+  }
+  const err = input.error as Error | undefined;
+  const updated: StepRecord = {
+    ...step,
+    status: "failed",
+    completedAt: new Date().toISOString(),
+    error: {
+      message: err?.message ?? String(input.error),
+      stack: err?.stack
+    }
+  };
+  const next = upsertStep(workflow, updated);
+  await writeWorkflow(next);
+}
+
+export async function recordStepPaused(input: StepFailureInput): Promise<void> {
+  const workflow = await readWorkflow(input.sessionId);
+  if (!workflow) {
+    throw new Error(`Workflow not initialized for session ${input.sessionId}`);
+  }
+  const step = workflow.steps.find(entry => entry.stepId === input.stepId);
+  if (!step) {
+    throw new Error(`Unknown step ${input.stepId} for session ${input.sessionId}`);
+  }
+  const err = input.error as Error | undefined;
+  const updated: StepRecord = {
+    ...step,
+    status: "paused",
+    completedAt: new Date().toISOString(),
+    error: {
+      message: err?.message ?? String(input.error),
+      stack: err?.stack
+    }
+  };
+  const next = upsertStep(workflow, updated);
+  await writeWorkflow(next);
+}
+
+export async function getNextSequence(sessionId: string): Promise<number> {
+  await ensureRoot();
+  const workflow = await readWorkflow(sessionId);
+  if (!workflow) {
+    return 0;
+  }
+  return workflow.cursor + 1;
+}

--- a/src/orchestrator/checkpointStore.ts
+++ b/src/orchestrator/checkpointStore.ts
@@ -5,6 +5,14 @@ import { randomUUID } from "node:crypto";
 
 export type StepStatus = "queued" | "running" | "completed" | "skipped" | "failed" | "paused";
 
+export interface PlannedStepRecord {
+  order: number;
+  stepType: string;
+  optional: boolean;
+  stopOnSuccess: boolean;
+  payload?: Record<string, unknown>;
+}
+
 export interface StepRecord {
   stepId: string;
   stepType: string;
@@ -24,6 +32,7 @@ export interface StepWorkflow {
   cursor: number;
   steps: StepRecord[];
   updatedAt: string;
+  plan?: PlannedStepRecord[];
 }
 
 interface StepQueuedInput {
@@ -72,6 +81,19 @@ function cloneValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+function clonePlan(plan: PlannedStepRecord[] | undefined): PlannedStepRecord[] | undefined {
+  if (!plan || plan.length === 0) {
+    return plan;
+  }
+  return plan.map(entry => ({
+    order: entry.order,
+    stepType: entry.stepType,
+    optional: Boolean(entry.optional),
+    stopOnSuccess: Boolean(entry.stopOnSuccess),
+    payload: cloneValue(entry.payload)
+  }));
+}
+
 async function readWorkflow(sessionId: string): Promise<StepWorkflow | null> {
   const safeId = sanitizeSessionId(sessionId);
   const filePath = path.join(WORKFLOW_ROOT, `${safeId}.json`);
@@ -105,7 +127,54 @@ function upsertStep(workflow: StepWorkflow, record: StepRecord): StepWorkflow {
   }
   const cursor = Math.max(workflow.cursor, record.sequence);
   const updatedAt = new Date().toISOString();
-  return { sessionId: workflow.sessionId, cursor, steps, updatedAt };
+  return {
+    sessionId: workflow.sessionId,
+    cursor,
+    steps,
+    updatedAt,
+    ...(workflow.plan ? { plan: clonePlan(workflow.plan) } : {})
+  };
+}
+
+function normalizePlan(plan: PlannedStepRecord[]): PlannedStepRecord[] {
+  return plan.map(entry => ({
+    order: entry.order,
+    stepType: entry.stepType,
+    optional: Boolean(entry.optional),
+    stopOnSuccess: Boolean(entry.stopOnSuccess),
+    payload: cloneValue(entry.payload)
+  }));
+}
+
+export async function initializeWorkflow(sessionId: string, plan: PlannedStepRecord[]): Promise<void> {
+  await ensureRoot();
+  const safeId = sanitizeSessionId(sessionId);
+  const workflow: StepWorkflow = {
+    sessionId: safeId,
+    cursor: -1,
+    steps: [],
+    updatedAt: new Date().toISOString(),
+    plan: normalizePlan(plan)
+  };
+  await writeWorkflow(workflow);
+}
+
+export async function ensureWorkflowPlan(sessionId: string, plan: PlannedStepRecord[]): Promise<void> {
+  await ensureRoot();
+  const safeId = sanitizeSessionId(sessionId);
+  const workflow = await readWorkflow(safeId);
+  if (!workflow) {
+    throw new Error(`Workflow not initialized for session ${sessionId}`);
+  }
+  if (workflow.plan && workflow.plan.length > 0) {
+    return;
+  }
+  const updated: StepWorkflow = {
+    ...workflow,
+    plan: normalizePlan(plan),
+    updatedAt: new Date().toISOString()
+  };
+  await writeWorkflow(updated);
 }
 
 export async function resetWorkflow(sessionId: string): Promise<void> {
@@ -127,7 +196,8 @@ export async function recordStepQueued(input: StepQueuedInput): Promise<StepReco
     sessionId,
     cursor: -1,
     steps: [],
-    updatedAt: new Date().toISOString()
+    updatedAt: new Date().toISOString(),
+    plan: undefined
   };
 
   const stepId = input.stepId ?? randomUUID();

--- a/src/orchestrator/jobQueue.ts
+++ b/src/orchestrator/jobQueue.ts
@@ -9,13 +9,23 @@ import type {
   SingleExecutionResult
 } from "./executionTypes.js";
 
+export interface StepJobPayload {
+  sessionId: string;
+  stepId: string;
+  stepType: string;
+  sequence: number;
+  payload?: Record<string, unknown>;
+}
+
 export type ExecutionJob =
   | { type: "plan"; payload: PlanExecutionOptions }
-  | { type: "single"; payload: SingleExecutionOptions };
+  | { type: "single"; payload: SingleExecutionOptions }
+  | { type: "step"; payload: StepJobPayload };
 
 export type ExecutionJobResult =
   | { type: "plan"; result: PlanExecutionJobResult }
-  | { type: "single"; result: SingleExecutionResult };
+  | { type: "single"; result: SingleExecutionResult }
+  | { type: "step"; result: unknown };
 
 export type ExecutionJobHandler = (job: ExecutionJob) => Promise<ExecutionJobResult>;
 
@@ -89,7 +99,7 @@ class BullMQExecutionQueue implements ExecutionQueueController {
     });
     this.worker = new Worker<ExecutionJob, ExecutionJobResult>(
       options.queueName,
-      async job => this.handler(job.data),
+      async (job: { data: ExecutionJob }) => this.handler(job.data),
       {
         connection: this.connection,
         concurrency: options.concurrency

--- a/src/orchestrator/stepQueue.ts
+++ b/src/orchestrator/stepQueue.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from "node:crypto";
+
+import { PausedError } from "./abortSignal.js";
+import {
+  configureExecutionQueue,
+  type ConfigureExecutionQueueOptions,
+  type ExecutionQueueController,
+  type ExecutionQueueMode,
+  type StepJobPayload
+} from "./jobQueue.js";
+import {
+  getNextSequence,
+  loadWorkflow,
+  recordStepCompletion,
+  recordStepFailure,
+  recordStepPaused,
+  recordStepQueued,
+  recordStepRunning,
+  resetWorkflow,
+  type StepRecord,
+  type StepStatus
+} from "./checkpointStore.js";
+
+export type ExecutionStepType =
+  | "clarify"
+  | "plan"
+  | "generate"
+  | "test"
+  | "repair"
+  | "single"
+  | "finalize";
+
+export interface StepHandlerContext {
+  sessionId: string;
+  stepId: string;
+  stepType: ExecutionStepType;
+  sequence: number;
+  payload?: Record<string, unknown>;
+  queueMode: ExecutionQueueMode;
+}
+
+export interface StepHandlerResult {
+  status?: "completed" | "skipped";
+  data?: Record<string, unknown>;
+  stop?: boolean;
+}
+
+export type StepHandler = (context: StepHandlerContext) => Promise<StepHandlerResult>;
+
+export interface StepDescriptor {
+  type: ExecutionStepType;
+  payload?: Record<string, unknown>;
+  stopOnSuccess?: boolean;
+  optional?: boolean;
+}
+
+export interface StepExecutionResult {
+  stepId: string;
+  stepType: ExecutionStepType;
+  status: StepStatus;
+  data?: Record<string, unknown>;
+  stop?: boolean;
+}
+
+export interface WorkflowRunResult {
+  steps: StepExecutionResult[];
+  last?: StepExecutionResult;
+}
+
+export class StepQueue {
+  private controller: ExecutionQueueController;
+  private readonly handlers = new Map<ExecutionStepType, StepHandler>();
+
+  private constructor(controller: ExecutionQueueController) {
+    this.controller = controller;
+  }
+
+  static async create(options?: ConfigureExecutionQueueOptions): Promise<StepQueue> {
+    let queue: StepQueue | null = null;
+    const controller = await configureExecutionQueue(async job => {
+      if (job.type !== "step") {
+        throw new Error(`Unsupported execution job type: ${(job as { type: string }).type}`);
+      }
+      if (!queue) {
+        throw new Error("StepQueue not initialized");
+      }
+      const result = await queue.handle(job.payload as StepJobPayload);
+      return { type: "step", result } as const;
+    }, options);
+
+    queue = new StepQueue(controller);
+    return queue;
+  }
+
+  get mode(): ExecutionQueueMode {
+    return this.controller.mode;
+  }
+
+  registerHandler(stepType: ExecutionStepType, handler: StepHandler): void {
+    this.handlers.set(stepType, handler);
+  }
+
+  async resetSession(sessionId: string): Promise<void> {
+    await resetWorkflow(sessionId);
+  }
+
+  async runWorkflow(sessionId: string, steps: StepDescriptor[]): Promise<WorkflowRunResult> {
+    if (!sessionId) {
+      throw new Error("sessionId is required to run workflow");
+    }
+
+    await this.resetSession(sessionId);
+    const results: StepExecutionResult[] = [];
+
+    for (const descriptor of steps) {
+      const { type, payload, stopOnSuccess = true, optional = false } = descriptor;
+      try {
+        const result = await this.enqueueStep({ sessionId, stepType: type, payload });
+        results.push(result);
+        const shouldStop = (result.status === "completed" && (result.stop ?? stopOnSuccess)) || result.status === "paused";
+        if (shouldStop) {
+          return { steps: results, last: result };
+        }
+        if (result.status === "skipped") {
+          continue;
+        }
+      } catch (error) {
+        if (error instanceof PausedError) {
+          throw error;
+        }
+        if (!optional) {
+          throw error;
+        }
+        // optional failure already recorded in checkpoint store
+      }
+    }
+
+    return { steps: results, last: results.at(-1) };
+  }
+
+  async enqueueStep({
+    sessionId,
+    stepType,
+    payload,
+    sequence
+  }: {
+    sessionId: string;
+    stepType: ExecutionStepType;
+    payload?: Record<string, unknown>;
+    sequence?: number;
+  }): Promise<StepExecutionResult> {
+    if (!sessionId) {
+      throw new Error("sessionId is required to enqueue step");
+    }
+
+    const currentSequence = sequence ?? (await getNextSequence(sessionId));
+    const job: StepJobPayload = {
+      sessionId,
+      stepId: randomUUID(),
+      stepType,
+      sequence: currentSequence,
+      payload: payload ? JSON.parse(JSON.stringify(payload)) : undefined
+    };
+
+    await recordStepQueued({
+      sessionId,
+      stepId: job.stepId,
+      stepType,
+      sequence: currentSequence,
+      payload: job.payload
+    });
+
+    const result = await this.controller.submit({ type: "step", payload: job });
+    if (result.type !== "step") {
+      throw new Error(`Unexpected job result type: ${(result as { type: string }).type}`);
+    }
+    return result.result as StepExecutionResult;
+  }
+
+  private async handle(job: StepJobPayload): Promise<StepExecutionResult> {
+    const stepType = job.stepType as ExecutionStepType;
+    const handler = this.handlers.get(stepType);
+    if (!handler) {
+      throw new Error(`No handler registered for step ${job.stepType}`);
+    }
+
+    await recordStepRunning(job.sessionId, job.stepId);
+    try {
+      const result = await handler({
+        sessionId: job.sessionId,
+        stepId: job.stepId,
+        stepType,
+        sequence: job.sequence,
+        payload: job.payload,
+        queueMode: this.controller.mode
+      });
+      const status: StepStatus = result.status ?? "completed";
+      await recordStepCompletion({
+        sessionId: job.sessionId,
+        stepId: job.stepId,
+        status,
+        result: result.data,
+        stop: result.stop
+      });
+      return {
+        stepId: job.stepId,
+        stepType,
+        status,
+        data: result.data,
+        stop: result.stop
+      };
+    } catch (error) {
+      if (error instanceof PausedError) {
+        await recordStepPaused({ sessionId: job.sessionId, stepId: job.stepId, error });
+      } else {
+        await recordStepFailure({ sessionId: job.sessionId, stepId: job.stepId, error });
+      }
+      throw error;
+    }
+  }
+
+  async getWorkflow(sessionId: string): Promise<StepRecord[] | null> {
+    const workflow = await loadWorkflow(sessionId);
+    return workflow?.steps ?? null;
+  }
+}

--- a/src/orchestrator/stepQueue.ts
+++ b/src/orchestrator/stepQueue.ts
@@ -9,7 +9,9 @@ import {
   type StepJobPayload
 } from "./jobQueue.js";
 import {
+  ensureWorkflowPlan,
   getNextSequence,
+  initializeWorkflow,
   loadWorkflow,
   recordStepCompletion,
   recordStepFailure,
@@ -17,6 +19,7 @@ import {
   recordStepQueued,
   recordStepRunning,
   resetWorkflow,
+  type PlannedStepRecord,
   type StepRecord,
   type StepStatus
 } from "./checkpointStore.js";
@@ -60,11 +63,17 @@ export interface StepExecutionResult {
   status: StepStatus;
   data?: Record<string, unknown>;
   stop?: boolean;
+  sequence: number;
 }
 
 export interface WorkflowRunResult {
   steps: StepExecutionResult[];
   last?: StepExecutionResult;
+}
+
+export interface WorkflowRunOptions {
+  resume?: boolean;
+  onStep?: (result: StepExecutionResult) => void;
 }
 
 export class StepQueue {
@@ -104,19 +113,73 @@ export class StepQueue {
     await resetWorkflow(sessionId);
   }
 
-  async runWorkflow(sessionId: string, steps: StepDescriptor[]): Promise<WorkflowRunResult> {
+  async runWorkflow(sessionId: string, steps: StepDescriptor[], options?: WorkflowRunOptions): Promise<WorkflowRunResult> {
     if (!sessionId) {
       throw new Error("sessionId is required to run workflow");
     }
 
-    await this.resetSession(sessionId);
+    const planned: PlannedStepRecord[] = steps.map((descriptor, index) => ({
+      order: index,
+      stepType: descriptor.type,
+      optional: Boolean(descriptor.optional),
+      stopOnSuccess: descriptor.stopOnSuccess ?? true,
+      payload: descriptor.payload ? JSON.parse(JSON.stringify(descriptor.payload)) : undefined
+    }));
+
+    if (options?.resume) {
+      const workflow = await loadWorkflow(sessionId);
+      if (!workflow) {
+        throw new Error(`Workflow not initialized for session ${sessionId}`);
+      }
+      await ensureWorkflowPlan(sessionId, planned);
+    } else {
+      await this.resetSession(sessionId);
+      await initializeWorkflow(sessionId, planned);
+    }
+
     const results: StepExecutionResult[] = [];
 
-    for (const descriptor of steps) {
+    for (let index = 0; index < steps.length; index += 1) {
+      const descriptor = steps[index];
+      if (!descriptor) {
+        continue;
+      }
       const { type, payload, stopOnSuccess = true, optional = false } = descriptor;
       try {
-        const result = await this.enqueueStep({ sessionId, stepType: type, payload });
+        const existingRecord = await this.selectRecordedStep(sessionId, index);
+
+        if (options?.resume) {
+          if (existingRecord && (existingRecord.status === "completed" || existingRecord.status === "skipped")) {
+            const carried: StepExecutionResult = {
+              stepId: existingRecord.stepId,
+              stepType: existingRecord.stepType as ExecutionStepType,
+              status: existingRecord.status,
+              data: existingRecord.result,
+              stop: existingRecord.stop,
+              sequence: index
+            };
+            results.push(carried);
+            options?.onStep?.(carried);
+            const shouldCarryStop =
+              carried.status === "completed" && (carried.stop ?? stopOnSuccess ?? true);
+            if (shouldCarryStop) {
+              return { steps: results, last: carried };
+            }
+            continue;
+          }
+        }
+
+        const plannedPayload = planned[index]?.payload;
+        const payloadForRun = payload ?? existingRecord?.payload ?? plannedPayload;
+
+        const result = await this.enqueueStep({
+          sessionId,
+          stepType: type,
+          payload: payloadForRun,
+          sequence: index
+        });
         results.push(result);
+        options?.onStep?.(result);
         const shouldStop = (result.status === "completed" && (result.stop ?? stopOnSuccess)) || result.status === "paused";
         if (shouldStop) {
           return { steps: results, last: result };
@@ -207,10 +270,14 @@ export class StepQueue {
         stepType,
         status,
         data: result.data,
-        stop: result.stop
+        stop: result.stop,
+        sequence: job.sequence
       };
     } catch (error) {
       if (error instanceof PausedError) {
+        error.stepId = job.stepId;
+        error.stepType = stepType;
+        error.sequence = job.sequence;
         await recordStepPaused({ sessionId: job.sessionId, stepId: job.stepId, error });
       } else {
         await recordStepFailure({ sessionId: job.sessionId, stepId: job.stepId, error });
@@ -222,5 +289,27 @@ export class StepQueue {
   async getWorkflow(sessionId: string): Promise<StepRecord[] | null> {
     const workflow = await loadWorkflow(sessionId);
     return workflow?.steps ?? null;
+  }
+
+  async getPlannedSteps(sessionId: string): Promise<PlannedStepRecord[] | null> {
+    const workflow = await loadWorkflow(sessionId);
+    return workflow?.plan ?? null;
+  }
+
+  private async selectRecordedStep(sessionId: string, sequence: number | null): Promise<StepRecord | undefined> {
+    if (sequence === null || sequence === undefined) {
+      return undefined;
+    }
+    const workflow = await loadWorkflow(sessionId);
+    if (!workflow) {
+      return undefined;
+    }
+    for (let index = workflow.steps.length - 1; index >= 0; index -= 1) {
+      const entry = workflow.steps[index];
+      if (entry && entry.sequence === sequence) {
+        return entry;
+      }
+    }
+    return undefined;
   }
 }

--- a/src/planning/decomposeTask.ts
+++ b/src/planning/decomposeTask.ts
@@ -152,10 +152,12 @@ async function requestPlan(
   previousIssues?: DecompositionIssue[]
 ): Promise<string> {
   const systemPrompt = buildPrompt(prompt, clarifications, previousIssues);
+  const trace = getTraceContext();
+  const sessionId = trace?.sessionId;
   return generateJSON([
     { role: "system", content: "You output JSON for task plans." },
     { role: "user", content: systemPrompt }
-  ]);
+  ], { sessionId });
 }
 
 function ms(n: number, fallback: number): number {

--- a/src/planning/generateSubtaskOutput.ts
+++ b/src/planning/generateSubtaskOutput.ts
@@ -36,7 +36,11 @@ export async function generateSubtaskOutputWithRetry(
       messages.splice(1, 0, { role: "system" as const, content: buildRetryMessage(lastError) });
     }
 
-  const raw = await withTraceContext({ phase: 'subtask', projectSlug: request?.subtask ? undefined : undefined }, async () => generateJSON(messages));
+    const raw = await withTraceContext({ phase: "subtask" }, async () => {
+      const trace = getTraceContext();
+      const sessionId = trace?.sessionId;
+      return generateJSON(messages, { sessionId });
+    });
 
     // Check if execution was paused immediately after LLM call completes
     // This catches pause requests that occurred during the LLM call

--- a/src/repair/multiTurnRepair.ts
+++ b/src/repair/multiTurnRepair.ts
@@ -352,8 +352,8 @@ export async function multiTurnRepair(context: MultiTurnContext): Promise<Repair
     let lastErrorMessage: string | undefined;
     try {
       async function requestPayload(withRetryHint: boolean): Promise<ParsedRepairPayload> {
-        const raw = await withTraceContext({ projectSlug: context.projectSlug, sessionId: context.sessionId, phase: 'repair' }, async () => generateJSON(
-          withRetryHint
+        const raw = await withTraceContext({ projectSlug: context.projectSlug, sessionId: context.sessionId, phase: "repair" }, async () => {
+          const payloadMessages = withRetryHint
             ? ([
                 messages[0]!,
                 {
@@ -363,8 +363,12 @@ export async function multiTurnRepair(context: MultiTurnContext): Promise<Repair
                     "\n\nIMPORTANT: For every artifact with action add/modify, include the full final file contents in files[]. If you cannot provide contents, omit that artifact."
                 }
               ] satisfies LLMMessage[])
-            : (messages as LLMMessage[])
-        ));
+            : (messages as LLMMessage[]);
+          return generateJSON(payloadMessages, { sessionId: context.sessionId });
+        });
+        if (context.sessionId) {
+          throwIfAborted(context.sessionId, "post_repair_llm");
+        }
         let parsed: unknown;
         try {
           parsed = JSON.parse(raw);

--- a/src/repair/repairOnce.ts
+++ b/src/repair/repairOnce.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 // Orchestrates a single repair attempt using the sandbox runner and LLM output.
 
 import { generateJSON, type LLMMessage } from "../llm/index.js";
+import { throwIfAborted } from "../orchestrator/abortSignal.js";
 import { runInSandbox } from "../runner/runInSandbox.js";
 import {
   validateRepairArtifact,
@@ -18,6 +19,7 @@ export interface RepairOnceArgs {
   failure: RunResult;
   originalFiles: ExecutorFile[];
   prompt: string;
+  sessionId?: string;
 }
 
 export interface RepairOutcome {
@@ -101,6 +103,7 @@ function validateArtifacts(rawArtifacts: unknown[]): RepairArtifactDescription[]
 }
 
 export async function repairOnce(args: RepairOnceArgs): Promise<RepairOutcome> {
+  const { sessionId } = args;
   const notes: string[] = [];
   if (!process.env.OPENAI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
     notes.push("NO_LLM");
@@ -116,7 +119,11 @@ export async function repairOnce(args: RepairOnceArgs): Promise<RepairOutcome> {
 
   let raw: string;
   try {
-    raw = await generateJSON(buildRepairPrompt(args));
+    throwIfAborted(sessionId, "repair_once_llm");
+    raw = await generateJSON(buildRepairPrompt(args), { sessionId });
+    if (sessionId) {
+      throwIfAborted(sessionId, "post_repair_once_llm");
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/src/runner/runInSandbox.ts
+++ b/src/runner/runInSandbox.ts
@@ -9,7 +9,7 @@ import { validateRunResult, type RunResult } from "../contracts/validators.js";
 import { ensureDependencies } from "./installDeps.js";
 import { detectTestCommand } from "./detectTestCommand.js";
 import { logEvaluationResult, type EvaluationResult } from "../evaluation/logResults.js";
-import { throwIfAborted } from "../orchestrator/abortSignal.js";
+import { throwIfAborted, onAbort, PausedError } from "../orchestrator/abortSignal.js";
 
 export interface RunInSandboxOptions {
   projectRoot: string;
@@ -21,6 +21,7 @@ export interface RunInSandboxOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+const SIGKILL_DELAY_MS = Number(process.env.SANDBOX_SIGKILL_DELAY_MS ?? 5_000);
 
 function parseCounts(log: string): { passCount: number; failCount: number } {
   let passCount = 0;
@@ -156,6 +157,32 @@ export async function runInSandbox(options: RunInSandboxOptions): Promise<RunRes
   });
 
   let timedOut = false;
+  let aborted = false;
+  let abortError: PausedError | undefined;
+  let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleSigkill = () => {
+    if (sigkillTimer) return;
+    sigkillTimer = setTimeout(() => {
+      killTree();
+    }, SIGKILL_DELAY_MS);
+    const maybeTimer = sigkillTimer as { unref?: () => void };
+    maybeTimer.unref?.();
+  };
+
+  if (sessionId) {
+    onAbort(sessionId, () => {
+      aborted = true;
+      abortError = new PausedError(sessionId, "testing");
+      try {
+        child.kill("SIGTERM");
+      } catch (_err) {
+        void _err;
+      }
+      scheduleSigkill();
+    });
+  }
+
   function killTree(): void {
     try {
       if (isWin) {
@@ -192,6 +219,9 @@ export async function runInSandbox(options: RunInSandboxOptions): Promise<RunRes
 
   const { code, signal } = await exitPromise.finally(() => {
     clearTimeout(timeoutHandle);
+    if (sigkillTimer) {
+      clearTimeout(sigkillTimer);
+    }
     logStream.end();
   });
 
@@ -218,6 +248,11 @@ export async function runInSandbox(options: RunInSandboxOptions): Promise<RunRes
     finishedAt: finishedAt.toISOString(),
     errorMessage: timedOut ? `Process timed out after ${timeoutMs}ms` : undefined
   };
+
+  if (aborted) {
+    const pauseError = abortError ?? new PausedError(sessionId ?? "sandbox", "testing");
+    throw pauseError;
+  }
 
   const validation = validateRunResult(runResult);
   if (!validation.ok) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -463,7 +463,12 @@ async function generateExecutorOutputFromPrompt(
     { role: "user" as const, content: userPrompt }
   ];
 
-  const raw = await withTraceContext({ phase: 'single' }, async () => generateJSON(messages));
+  const raw = await withTraceContext({ phase: "single", sessionId }, async () => {
+    return generateJSON(messages, { sessionId });
+  });
+  if (sessionId) {
+    throwIfAborted(sessionId, "post_single_llm");
+  }
   let data: unknown;
   try {
     data = JSON.parse(raw);

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,11 +65,7 @@ import {
 } from "./orchestrator/resume.js";
 import { captureManifest, getManifest } from "./orchestrator/workspaceManifest.js";
 import { buildResumePrompts } from "./orchestrator/resumePrompt.js";
-import {
-  configureExecutionQueue,
-  createPlanJobPayload,
-  createSingleJobPayload
-} from "./orchestrator/jobQueue.js";
+import { StepQueue, type StepDescriptor, type StepHandler } from "./orchestrator/stepQueue.js";
 import type {
   ExecutorSuccessResponse,
   PlanExecutionJobResult,
@@ -1075,17 +1071,115 @@ async function runSingleExecution(options: SingleExecutionOptions): Promise<Sing
   }
 }
 
-const executionQueue = await configureExecutionQueue(async job => {
-  if (job.type === "plan") {
-    const planResult = await executePlanFlow(job.payload);
-    return { type: "plan", result: planResult } as const;
+type PlanStepPayload = {
+  systemPrompt: string;
+  effectivePrompt: string;
+  originalPrompt: string;
+  clarifications?: ClarificationResponse;
+  clarificationsUsed: boolean;
+  clarificationQuestions: ClarificationQuestion[];
+  clarificationAsked: boolean;
+  projectNameInput: string;
+  queueMetadata?: Record<string, unknown>;
+};
+
+type SingleStepPayload = {
+  singleOptions: SingleExecutionOptions;
+};
+
+const planStepHandler: StepHandler = async ({
+  sessionId,
+  payload,
+  queueMode
+}) => {
+  const data = (payload ?? {}) as PlanStepPayload;
+  if (queueMode === "bullmq" && data.queueMetadata) {
+    setProgress(sessionId, "planning", 20, data.queueMetadata);
   }
-  if (job.type === "single") {
-    const singleResult = await runSingleExecution(job.payload);
-    return { type: "single", result: singleResult } as const;
+
+  try {
+    throwIfAborted(sessionId, "decomposition");
+
+    const baseSlugPre = slugify(data.projectNameInput || "session", { lower: true, strict: true }) || "session";
+    const plan = await withTraceContext({ projectSlug: baseSlugPre, sessionId, phase: "decompose" }, async () =>
+      decomposeTask(data.effectivePrompt, data.clarifications)
+    );
+    const quality = validateDecomposition(plan, data.effectivePrompt);
+    if (quality.score < 70) {
+      return { status: "skipped" };
+    }
+
+    const planProjectName = data.projectNameInput || plan.originalPrompt || "planned-project";
+    const slug = slugify(planProjectName, { lower: true, strict: true }) || `planned-${Date.now()}`;
+    const targetRoot = path.join(OUTPUT_DIR, slug);
+
+    const planOptions: PlanExecutionOptions = {
+      plan,
+      planQuality: quality.score,
+      targetRoot,
+      slug,
+      effectivePrompt: data.effectivePrompt,
+      originalPrompt: data.originalPrompt,
+      clarifications: data.clarifications,
+      clarificationsUsed: data.clarificationsUsed,
+      systemPrompt: data.systemPrompt,
+      clarificationQuestions: data.clarificationQuestions,
+      clarificationsAsked: data.clarificationAsked,
+      projectName: planProjectName,
+      sessionId
+    };
+
+    const planResult = await executePlanFlow(planOptions);
+    const response = planResult.response as ExecutorSuccessResponse;
+    return { status: "completed", data: { response, slug, targetRoot }, stop: true };
+  } catch (error) {
+    if (error instanceof PausedError) {
+      throw error;
+    }
+    console.warn("Planning execution failed, falling back to single execution", error);
+    try {
+      const session = ensureOrchestrationSession(sessionId);
+      if (session.machine.state === "PLANNING") {
+        session.machine.transition("GENERATING", { reason: "fallback_to_single_after_plan_error" });
+      }
+    } catch (transitionErr) {
+      console.warn("Could not transition state during plan fallback:", transitionErr);
+    }
+    return { status: "skipped" };
   }
-  throw new Error(`Unsupported execution job type: ${(job as { type: string }).type}`);
-});
+};
+
+const singleStepHandler: StepHandler = async ({ payload, queueMode }) => {
+  const data = (payload ?? {}) as SingleStepPayload;
+  if (!data.singleOptions) {
+    throw new Error("singleOptions payload required for single step");
+  }
+
+  const baseOptions = data.singleOptions;
+  const options: SingleExecutionOptions = {
+    ...baseOptions,
+    progressMetadata: baseOptions.progressMetadata ? { ...baseOptions.progressMetadata } : undefined
+  };
+
+  if (queueMode === "bullmq") {
+    const queuedMeta = { ...(options.progressMetadata ?? {}), queued: true, mode: "queue" };
+    options.progressMetadata = queuedMeta;
+    if (options.sessionId) {
+      setProgress(options.sessionId, "planning", 20, queuedMeta);
+    }
+  }
+
+  const result = await runSingleExecution(options);
+  return {
+    status: "completed",
+    data: { response: result.response, slug: result.slug, targetRoot: result.targetRoot },
+    stop: true
+  };
+};
+
+const stepQueue = await StepQueue.create();
+stepQueue.registerHandler("plan", planStepHandler);
+stepQueue.registerHandler("single", singleStepHandler);
 
 async function resolveSessionPrompts(
   sessionId: string,
@@ -1146,10 +1240,12 @@ app.post("/api/execute", async (req, res) => {
   const sessionId: string | undefined = typeof req.body?.sessionId === 'string' ? req.body.sessionId : undefined;
   
   try {
-    // Create abort signal for pause functionality
-    if (sessionId) {
-      createAbortSignal(sessionId);
+    if (!sessionId) {
+      return res.status(400).json({ error: "session id required" });
     }
+
+    // Create abort signal for pause functionality
+    createAbortSignal(sessionId);
     
     setProgress(sessionId, "analyzing", 10);
     const promptRaw = req.body?.prompt;
@@ -1204,124 +1300,53 @@ app.post("/api/execute", async (req, res) => {
       clarificationAsked = clarificationQuestions.length > 0;
     }
 
+    const queueMetadata = stepQueue.mode === "bullmq" ? { queued: true, mode: "queue" } : undefined;
+
+    const steps: StepDescriptor[] = [];
+
     if (isComplexPrompt(effectivePrompt, clarifications)) {
-      try {
-        // Check if execution was paused before decomposition
-        throwIfAborted(sessionId, "decomposition");
-        
-        const baseSlugPre = slugify(projectNameInput || "session", { lower: true, strict: true }) || "session";
-        const plan = await withTraceContext({ projectSlug: baseSlugPre, sessionId, phase: 'decompose' }, async () =>
-          decomposeTask(effectivePrompt, clarifications)
-        );
-        const quality = validateDecomposition(plan, effectivePrompt);
-        if (quality.score >= 70) {
-          const planProjectName = projectNameInput || plan.originalPrompt || "planned-project";
-          const slug = slugify(planProjectName, { lower: true, strict: true }) || `planned-${Date.now()}`;
-          const targetRoot = path.join(OUTPUT_DIR, slug);
-
-          try {
-            const planJob = createPlanJobPayload({
-              plan,
-              planQuality: quality.score,
-              targetRoot,
-              slug,
-              effectivePrompt,
-              originalPrompt,
-              clarifications,
-              clarificationsUsed,
-              systemPrompt,
-              clarificationQuestions,
-              clarificationsAsked: clarificationAsked,
-              projectName: planProjectName,
-              sessionId
-            });
-            if (executionQueue.mode === "bullmq") {
-              setProgress(sessionId, "planning", 20, { queued: true, mode: "queue" });
-            }
-            const planResultJob = await executionQueue.submit(planJob);
-            const planResult = planResultJob.type === "plan" ? planResultJob.result : null;
-            if (!planResult) {
-              throw new Error("Plan job returned unexpected result type");
-            }
-            setProgress(sessionId, "finalizing", 95);
-            return res.json(planResult.response);
-          } catch (planError) {
-            if (planError instanceof PausedError) {
-              throw planError;
-            }
-            console.error("Plan execution failed, falling back to single execution", planError);
-            // Transition state machine when falling back from plan execution to single
-            if (sessionId) {
-              try {
-                const session = ensureOrchestrationSession(sessionId);
-                // If we're in PLANNING and falling back, transition to GENERATING for single execution
-                if (session.machine.state === "PLANNING") {
-                  session.machine.transition("GENERATING", { reason: "fallback_to_single_after_plan_error" });
-                }
-              } catch (transitionErr) {
-                console.warn("Could not transition state during fallback:", transitionErr);
-              }
-            }
-            // Fall through to single execution below
-          }
-        }
-      } catch (error) {
-        if (error instanceof PausedError) {
-          throw error;
-        }
-        console.warn("Planning decomposition failed, falling back to single execution", error);
-        // Transition state machine when falling back from planning to single
-        if (sessionId) {
-          try {
-            const session = ensureOrchestrationSession(sessionId);
-            // If we're in PLANNING and falling back, transition to GENERATING for single execution
-            if (session.machine.state === "PLANNING") {
-              session.machine.transition("GENERATING", { reason: "fallback_to_single_after_planning_failure" });
-            }
-          } catch (transitionErr) {
-            console.warn("Could not transition state during fallback:", transitionErr);
-          }
-        }
-        // Fall through to single execution below
-      }
-    }
-
-    try {
-      const singleOptions: SingleExecutionOptions = {
-        sessionId,
+      const planPayload: PlanStepPayload = {
         systemPrompt,
-        executorPrompt: effectivePrompt,
+        effectivePrompt,
         originalPrompt,
-        projectNameHint: projectNameInput,
         clarifications,
         clarificationsUsed,
         clarificationQuestions,
         clarificationAsked,
-        preserveWorkspace: false,
-        tracePhase: "single"
+        projectNameInput,
+        queueMetadata
       };
-      if (executionQueue.mode === "bullmq") {
-        singleOptions.progressMetadata = { queued: true };
-      }
-      const singleJob = createSingleJobPayload(singleOptions);
-      if (executionQueue.mode === "bullmq") {
-        setProgress(sessionId, "planning", 20, { queued: true, mode: "queue" });
-      }
-      const resultJob = await executionQueue.submit(singleJob);
-      const result = resultJob.type === "single" ? resultJob.result : null;
-      if (!result) {
-        throw new Error("Single execution job returned unexpected result type");
-      }
-      return res.json(result.response);
-    } catch (error) {
-      if (error instanceof PausedError) {
-        throw error;
-      }
-      if (error instanceof Error && (error as { statusCode?: number }).statusCode === 422) {
-        return res.status(422).json({ error: error.message });
-      }
-      throw error;
+      steps.push({ type: "plan", payload: planPayload, stopOnSuccess: true, optional: true });
     }
+
+    const singleOptions: SingleExecutionOptions = {
+      sessionId,
+      systemPrompt,
+      executorPrompt: effectivePrompt,
+      originalPrompt,
+      projectNameHint: projectNameInput,
+      clarifications,
+      clarificationsUsed,
+      clarificationQuestions,
+      clarificationAsked,
+      preserveWorkspace: false,
+      tracePhase: "single"
+    };
+
+    if (queueMetadata) {
+      singleOptions.progressMetadata = { ...queueMetadata };
+    }
+
+    const singlePayload: SingleStepPayload = { singleOptions };
+    steps.push({ type: "single", payload: singlePayload, stopOnSuccess: true });
+
+    const workflow = await stepQueue.runWorkflow(sessionId, steps);
+    const finalStep = workflow.last;
+    const responsePayload = finalStep?.data?.response as ExecutorSuccessResponse | undefined;
+    if (!responsePayload) {
+      throw new Error("Execution pipeline did not produce a response payload");
+    }
+    return res.json(responsePayload);
   } catch (err: unknown) {
     // Handle pause interruption gracefully
     if (err instanceof PausedError) {
@@ -1699,14 +1724,12 @@ app.post("/api/sessions/:id/resume", async (req, res) => {
         progressMetadata
       };
 
-      if (executionQueue.mode === "bullmq") {
-        const queuedMeta = { ...progressMetadata, queued: true, mode: "queue" };
-        resumeOptions.progressMetadata = queuedMeta;
-        setProgress(sessionId, "planning", 20, queuedMeta);
+      if (stepQueue.mode === "bullmq") {
+        resumeOptions.progressMetadata = { ...progressMetadata, queued: true, mode: "queue" };
       }
 
-      executionQueue
-        .submit(createSingleJobPayload(resumeOptions))
+      stepQueue
+        .enqueueStep({ sessionId, stepType: "single", payload: { singleOptions: resumeOptions } })
         .catch(error => {
           if (error instanceof PausedError) {
             return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1237,16 +1237,46 @@ app.post("/api/clarify", (req, res) => {
 });
 
 app.post("/api/execute", async (req, res) => {
-  const sessionId: string | undefined = typeof req.body?.sessionId === 'string' ? req.body.sessionId : undefined;
-  
+  const sessionId: string | undefined = typeof req.body?.sessionId === "string" ? req.body.sessionId : undefined;
+  const wantsSse = typeof req.headers.accept === "string" && req.headers.accept.includes("text/event-stream");
+  let sseStarted = false;
+
+  const ensureSse = () => {
+    if (!wantsSse || sseStarted) {
+      return;
+    }
+    sseStarted = true;
+    res.status(202);
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+  };
+
+  const sendSse = (event: string, data: unknown) => {
+    if (!wantsSse) {
+      return;
+    }
+    ensureSse();
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  const closeSse = () => {
+    if (!wantsSse) {
+      return;
+    }
+    ensureSse();
+    res.end();
+  };
+
   try {
     if (!sessionId) {
       return res.status(400).json({ error: "session id required" });
     }
 
-    // Create abort signal for pause functionality
     createAbortSignal(sessionId);
-    
+
     setProgress(sessionId, "analyzing", 10);
     const promptRaw = req.body?.prompt;
     const originalPrompt: string = promptRaw === undefined ? "" : promptRaw.toString();
@@ -1275,12 +1305,17 @@ app.post("/api/execute", async (req, res) => {
         effectivePrompt = augmented;
       }
     }
-    // Capture clarify/effective prompt fixtures for replay
-    await captureFixture(sessionId, slugify(projectNameRaw || "session", { lower: true, strict: true }) || "session", "clarify.json", {
-      originalPrompt,
-      effectivePrompt,
-      clarifications
-    });
+
+    await captureFixture(
+      sessionId,
+      slugify(projectNameRaw || "session", { lower: true, strict: true }) || "session",
+      "clarify.json",
+      {
+        originalPrompt,
+        effectivePrompt,
+        clarifications
+      }
+    );
 
     const systemPrompt = await fs.readFile("src/executor/systemPrompt.md", "utf-8");
     const projectNameInput = typeof projectNameRaw === "string" ? projectNameRaw.trim() : "";
@@ -1340,38 +1375,74 @@ app.post("/api/execute", async (req, res) => {
     const singlePayload: SingleStepPayload = { singleOptions };
     steps.push({ type: "single", payload: singlePayload, stopOnSuccess: true });
 
-    const workflow = await stepQueue.runWorkflow(sessionId, steps);
+    const workflow = await stepQueue.runWorkflow(sessionId, steps, {
+      onStep: step => {
+        sendSse("step", {
+          sessionId,
+          stepId: step.stepId,
+          stepType: step.stepType,
+          status: step.status,
+          sequence: step.sequence,
+          stop: Boolean(step.stop),
+          timestamp: new Date().toISOString()
+        });
+      }
+    });
+
     const finalStep = workflow.last;
     const responsePayload = finalStep?.data?.response as ExecutorSuccessResponse | undefined;
     if (!responsePayload) {
       throw new Error("Execution pipeline did not produce a response payload");
     }
+
+    if (wantsSse) {
+      sendSse("completed", { sessionId, response: responsePayload });
+      closeSse();
+      return;
+    }
+
     return res.json(responsePayload);
   } catch (err: unknown) {
-    // Handle pause interruption gracefully
     if (err instanceof PausedError) {
       console.log(`Execution paused for session ${err.sessionId} during ${err.phase}`);
-      if (sessionId) {
-        cleanupAbortSignal(sessionId);
-      }
-      return res.status(202).json({
+      const workflowSteps = sessionId ? await stepQueue.getWorkflow(sessionId) : null;
+      const pausedRecord = workflowSteps?.slice().reverse().find(step => step.status === "paused");
+      const stepMeta = pausedRecord
+        ? { stepId: pausedRecord.stepId, stepType: pausedRecord.stepType, sequence: pausedRecord.sequence }
+        : {
+            stepId: err.stepId,
+            stepType: err.stepType,
+            sequence: err.sequence
+          };
+      const payload = {
         paused: true,
         sessionId: err.sessionId,
         phase: err.phase,
-        message: err.message
-      });
+        message: err.message,
+        ...stepMeta
+      };
+
+      if (wantsSse) {
+        res.status(202);
+        sendSse("paused", payload);
+        closeSse();
+        return;
+      }
+
+      return res.status(202).json(payload);
     }
-    
-    // Clean up abort signal on error
-    if (sessionId) {
-      cleanupAbortSignal(sessionId);
-    }
-    
+
     console.error(err);
     const message = err instanceof Error ? err.message : "internal error";
+
+    if (wantsSse) {
+      sendSse("error", { sessionId, message });
+      closeSse();
+      return;
+    }
+
     return res.status(500).json({ error: message });
   } finally {
-    // Safety cleanup in case catch doesn't execute
     if (sessionId) {
       cleanupAbortSignal(sessionId);
     }
@@ -1728,8 +1799,61 @@ app.post("/api/sessions/:id/resume", async (req, res) => {
         resumeOptions.progressMetadata = { ...progressMetadata, queued: true, mode: "queue" };
       }
 
+      const plannedSteps = await stepQueue.getPlannedSteps(sessionId);
+
+      type PlanEntry = {
+        order: number;
+        stepType: string;
+        optional: boolean;
+        stopOnSuccess: boolean;
+        payload?: Record<string, unknown>;
+      };
+
+      const orderedPlan: PlanEntry[] = plannedSteps && plannedSteps.length > 0
+        ? plannedSteps
+            .slice()
+            .sort((a, b) => a.order - b.order)
+            .map(entry => ({
+              order: entry.order,
+              stepType: entry.stepType,
+              optional: entry.optional,
+              stopOnSuccess: entry.stopOnSuccess,
+              payload: entry.payload
+                ? (JSON.parse(JSON.stringify(entry.payload)) as Record<string, unknown>)
+                : undefined
+            }))
+        : [
+            {
+              order: 0,
+              stepType: "single",
+              optional: false,
+              stopOnSuccess: true,
+              payload: { singleOptions: resumeOptions }
+            }
+          ];
+
+      const descriptors: StepDescriptor[] = orderedPlan.map(entry => {
+        const basePayload = entry.payload ? { ...entry.payload } : undefined;
+        if (entry.stepType === "single") {
+          const payload: Record<string, unknown> = basePayload ? { ...basePayload } : {};
+          payload.singleOptions = resumeOptions;
+          return {
+            type: entry.stepType as StepDescriptor["type"],
+            payload,
+            optional: entry.optional,
+            stopOnSuccess: entry.stopOnSuccess
+          };
+        }
+        return {
+          type: entry.stepType as StepDescriptor["type"],
+          payload: basePayload,
+          optional: entry.optional,
+          stopOnSuccess: entry.stopOnSuccess
+        };
+      });
+
       stepQueue
-        .enqueueStep({ sessionId, stepType: "single", payload: { singleOptions: resumeOptions } })
+        .runWorkflow(sessionId, descriptors, { resume: true })
         .catch(error => {
           if (error instanceof PausedError) {
             return;
@@ -1737,6 +1861,8 @@ app.post("/api/sessions/:id/resume", async (req, res) => {
           const message = error instanceof Error ? error.message : "resume execution failed";
           console.error(`[Resume] Execution failed for session ${sessionId}:`, error);
           setProgress(sessionId, "finalizing", 100, { resume: true, error: message }, true);
+        })
+        .finally(() => {
           cleanupAbortSignal(sessionId);
         });
     }

--- a/src/types/bullmq-shim.d.ts
+++ b/src/types/bullmq-shim.d.ts
@@ -1,0 +1,26 @@
+declare module "bullmq" {
+  export interface JobsOptions {
+    removeOnComplete?: number | boolean;
+    removeOnFail?: number | boolean;
+    [key: string]: unknown;
+  }
+
+  export class Queue<T = unknown> {
+    constructor(name: string, options?: { connection?: unknown });
+    waitUntilReady?(): Promise<void>;
+    add(name: string, data: T, options?: JobsOptions): Promise<{ waitUntilFinished(events: QueueEvents): Promise<unknown> }>;
+    close(): Promise<void>;
+  }
+
+  export class QueueEvents {
+    constructor(name: string, options?: { connection?: unknown });
+    waitUntilReady(): Promise<void>;
+    close(): Promise<void>;
+  }
+
+  export class Worker<T = unknown, R = unknown> {
+    constructor(name: string, processor: (job: { data: T }) => Promise<R>, options?: { connection?: unknown; concurrency?: number });
+    waitUntilReady(): Promise<void>;
+    close(): Promise<void>;
+  }
+}

--- a/src/types/ioredis-shim.d.ts
+++ b/src/types/ioredis-shim.d.ts
@@ -1,0 +1,7 @@
+declare module "ioredis" {
+  export default class IORedis {
+    constructor(connection: string, options?: Record<string, unknown>);
+    waitUntilReady?(): Promise<void>;
+    quit(): Promise<void>;
+  }
+}

--- a/tests/llm/abortSignal.test.ts
+++ b/tests/llm/abortSignal.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const { chooseProviderMock } = vi.hoisted(() => ({ chooseProviderMock: vi.fn() }));
+
+vi.mock("../../src/llm/providers/choose.js", () => ({
+  chooseProvider: (...args: unknown[]) => chooseProviderMock(...args)
+}));
+
+import { generateJSON } from "../../src/llm/index.js";
+import {
+  createAbortSignal,
+  abortSession,
+  cleanupAbortSignal,
+  PausedError
+} from "../../src/orchestrator/abortSignal.js";
+
+describe("generateJSON abort propagation", () => {
+  afterEach(() => {
+    chooseProviderMock.mockReset();
+  });
+
+  it("throws PausedError when session aborts during provider execution", async () => {
+    vi.useFakeTimers();
+    const sessionId = "abort-session";
+
+    chooseProviderMock.mockReturnValue({
+      generate: vi.fn((_messages: unknown, options: { signal?: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal?.reason ?? new Error("aborted")),
+            { once: true }
+          );
+          setTimeout(() => resolve({ content: "{\"ok\":true}" }), 1_000).unref?.();
+        })
+      )
+    });
+
+    createAbortSignal(sessionId);
+    try {
+      const promise = generateJSON([{ role: "user", content: "hello" }], { sessionId });
+      abortSession(sessionId);
+      await expect(promise).rejects.toBeInstanceOf(PausedError);
+    } finally {
+      cleanupAbortSignal(sessionId);
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/orchestrator/stepQueue.test.ts
+++ b/tests/orchestrator/stepQueue.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { PausedError } from "../../src/orchestrator/abortSignal.js";
+import { loadWorkflow } from "../../src/orchestrator/checkpointStore.js";
+import { StepQueue } from "../../src/orchestrator/stepQueue.js";
+import { resetExecutionQueueForTests } from "../../src/orchestrator/jobQueue.js";
+
+const WORKFLOW_ROOT = path.resolve(".automation", "checkpoints", "step-workflows");
+
+async function clearWorkflows() {
+  await fs.rm(WORKFLOW_ROOT, { recursive: true, force: true });
+}
+
+describe("StepQueue", () => {
+  beforeEach(async () => {
+    await clearWorkflows();
+    resetExecutionQueueForTests();
+  });
+
+  afterEach(async () => {
+    await clearWorkflows();
+    resetExecutionQueueForTests();
+  });
+
+  it("executes registered steps and persists completion", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+    queue.registerHandler("clarify", async context => {
+      expect(context.sessionId).toBe("session-alpha");
+      expect(context.queueMode).toBe("inline");
+      return { status: "completed", data: { note: "clarified" }, stop: true };
+    });
+
+    const result = await queue.runWorkflow("session-alpha", [{ type: "clarify" }]);
+    expect(result.last?.status).toBe("completed");
+    expect(result.last?.data).toEqual({ note: "clarified" });
+
+    const workflow = await loadWorkflow("session-alpha");
+    expect(workflow).not.toBeNull();
+    expect(workflow?.steps).toHaveLength(1);
+    expect(workflow?.steps[0]?.status).toBe("completed");
+    expect(workflow?.steps[0]?.result).toEqual({ note: "clarified" });
+  });
+
+  it("continues optional steps after failure and records status", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+
+    queue.registerHandler("plan", async () => {
+      throw new Error("plan failed");
+    });
+
+    queue.registerHandler("single", async () => {
+      return { status: "completed", data: { response: { ok: true } }, stop: true };
+    });
+
+    const result = await queue.runWorkflow("session-beta", [
+      { type: "plan", optional: true },
+      { type: "single" }
+    ]);
+
+    expect(result.steps).toHaveLength(1);
+    expect(result.last?.stepType).toBe("single");
+    expect(result.last?.status).toBe("completed");
+
+    const workflow = await loadWorkflow("session-beta");
+    expect(workflow?.steps).toHaveLength(2);
+    const [planStep, singleStep] = workflow!.steps;
+    expect(planStep.status).toBe("failed");
+    expect(singleStep.status).toBe("completed");
+  });
+
+  it("propagates pauses and records paused status", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+
+    queue.registerHandler("generate", async ({ sessionId }) => {
+      throw new PausedError(sessionId, "generate");
+    });
+
+    await expect(() => queue.runWorkflow("session-gamma", [{ type: "generate" }])).rejects.toThrow(PausedError);
+
+    const workflow = await loadWorkflow("session-gamma");
+    expect(workflow?.steps).toHaveLength(1);
+    expect(workflow?.steps[0]?.status).toBe("paused");
+  });
+
+  it("allows enqueuing additional steps without resetting history", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+
+    queue.registerHandler("clarify", async () => ({ status: "completed" }));
+    queue.registerHandler("single", async () => ({ status: "completed", data: { done: true }, stop: true }));
+
+    await queue.runWorkflow("session-delta", [{ type: "clarify" }]);
+    await queue.enqueueStep({ sessionId: "session-delta", stepType: "single" });
+
+    const workflow = await loadWorkflow("session-delta");
+    expect(workflow?.steps).toHaveLength(2);
+    expect(workflow?.steps[1]?.status).toBe("completed");
+  });
+
+  it("resetSession clears prior checkpoints", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+    queue.registerHandler("clarify", async () => ({ status: "completed" }));
+
+    await queue.runWorkflow("session-epsilon", [{ type: "clarify" }]);
+    await queue.resetSession("session-epsilon");
+
+    const workflow = await loadWorkflow("session-epsilon");
+    expect(workflow).toBeNull();
+  });
+});

--- a/tests/orchestrator/stepQueue.test.ts
+++ b/tests/orchestrator/stepQueue.test.ts
@@ -99,6 +99,32 @@ describe("StepQueue", () => {
     expect(workflow?.steps[1]?.status).toBe("completed");
   });
 
+  it("replays paused steps on resume using stored plan payload", async () => {
+    const queue = await StepQueue.create({ mode: "inline" });
+    let invocation = 0;
+
+    queue.registerHandler("single", async ({ sessionId, payload }) => {
+      invocation += 1;
+      expect(payload).toEqual({ singleOptions: { prompt: "resume" } });
+      if (invocation === 1) {
+        throw new PausedError(sessionId, "single");
+      }
+      return { status: "completed", data: { ok: true }, stop: true };
+    });
+
+    const firstDescriptor = [{ type: "single", payload: { singleOptions: { prompt: "resume" } } }];
+    await expect(queue.runWorkflow("session-resume", firstDescriptor)).rejects.toThrow(PausedError);
+
+    const workflowAfterPause = await loadWorkflow("session-resume");
+    expect(workflowAfterPause?.plan?.[0]?.payload).toEqual({ singleOptions: { prompt: "resume" } });
+    expect(workflowAfterPause?.steps.at(-1)?.status).toBe("paused");
+
+    const resumed = await queue.runWorkflow("session-resume", [{ type: "single" }], { resume: true });
+    expect(resumed.last?.status).toBe("completed");
+    expect(resumed.last?.sequence).toBe(0);
+    expect(invocation).toBe(2);
+  });
+
   it("resetSession clears prior checkpoints", async () => {
     const queue = await StepQueue.create({ mode: "inline" });
     queue.registerHandler("clarify", async () => ({ status: "completed" }));

--- a/tests/runner/runInSandbox.abort.test.ts
+++ b/tests/runner/runInSandbox.abort.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn(() => true);
+  pid = 4321;
+}
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args)
+}));
+import { runInSandbox } from "../../src/runner/runInSandbox.js";
+import {
+  createAbortSignal,
+  abortSession,
+  cleanupAbortSignal,
+  PausedError
+} from "../../src/orchestrator/abortSignal.js";
+import * as installDepsModule from "../../src/runner/installDeps.js";
+import * as detectTestCommandModule from "../../src/runner/detectTestCommand.js";
+
+describe("runInSandbox abort handling", () => {
+  const tempDirs: string[] = [];
+  let processKillSpy: ReturnType<typeof vi.spyOn<typeof process, "kill">>;
+  let ensureDependenciesSpy: ReturnType<typeof vi.spyOn> | undefined;
+  let detectTestCommandSpy: ReturnType<typeof vi.spyOn> | undefined;
+  let onSpawn: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spawnMock.mockImplementation(() => {
+      const child = new MockChildProcess();
+      setTimeout(() => {
+        child.stdout.emit("data", Buffer.from("running\n"));
+      }, 1).unref?.();
+      onSpawn?.();
+      return child as unknown as ReturnType<typeof spawnMock>;
+    });
+    ensureDependenciesSpy = vi
+      .spyOn(installDepsModule, "ensureDependencies")
+      .mockResolvedValue({ installed: false, command: null });
+    detectTestCommandSpy = vi
+      .spyOn(detectTestCommandModule, "detectTestCommand")
+      .mockReturnValue("npm test");
+    processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    spawnMock.mockReset();
+    ensureDependenciesSpy?.mockRestore();
+    detectTestCommandSpy?.mockRestore();
+    ensureDependenciesSpy = undefined;
+    detectTestCommandSpy = undefined;
+    onSpawn = undefined;
+    processKillSpy.mockRestore();
+    while (tempDirs.length) {
+      const dir = tempDirs.pop();
+      if (dir) await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("terminates child process promptly when paused", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-abort-"));
+    tempDirs.push(root);
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "demo", version: "0.0.0" }),
+      "utf-8"
+    );
+
+    const sessionId = "sandbox-session";
+    createAbortSignal(sessionId);
+
+    const promise = runInSandbox({ projectRoot: root, projectSlug: "demo", sessionId, timeoutMs: 5000 });
+
+    await new Promise<void>(resolve => {
+      if (spawnMock.mock.calls.length > 0) {
+        resolve();
+      } else {
+        onSpawn = resolve;
+      }
+    });
+
+    const child = spawnMock.mock.results[0]?.value as unknown as MockChildProcess | undefined;
+    expect(child).toBeDefined();
+    if (!child) throw new Error("child process was not spawned");
+
+    try {
+      abortSession(sessionId);
+
+      await vi.advanceTimersByTimeAsync(5);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+      setTimeout(() => {
+        child.emit("exit", null, null);
+      }, 5100).unref?.();
+
+      await vi.advanceTimersByTimeAsync(5100);
+
+      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+      expect(processKillSpy).toHaveBeenCalledWith(-child.pid, "SIGKILL");
+
+      await expect(promise).rejects.toBeInstanceOf(PausedError);
+    } finally {
+      cleanupAbortSignal(sessionId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- document current pause/resume integration points for Phase E hardening discovery
- add a checkpoint store and step queue orchestration layer with BullMQ-compatible jobs
- refactor /api/execute and resume flows to use step-based execution and add targeted StepQueue tests
- add lightweight type shims for bullmq and ioredis to satisfy type checking

## Testing
- npm run lint
- npm run typecheck
- npm test -- tests/orchestrator/stepQueue.test.ts *(fails: rollup optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea1f3d6454832abdc8713eda449c03