### PR TITLE
Document workflow validation findings and add remediation contract

### DIFF
--- a/contracts/Roadmap_workflow/05_workflow_phase1-4_remediation_execution_contract.json
+++ b/contracts/Roadmap_workflow/05_workflow_phase1-4_remediation_execution_contract.json
@@ -1,0 +1,481 @@
+{
+  "contract_version": "5.0.0",
+  "contract_meta": {
+    "created": "2025-10-15",
+    "phase": "5",
+    "phase_name": "Workflow Phase 1-4 Remediation & Gate Closure",
+    "prerequisite_phase": "Workflow Phases 1-4 initial implementation",
+    "supersedes": null,
+    "status": "active",
+    "enhancement": "Restore track separation by removing workflow contamination from the Executor MVP runtime and completing evidence capture for workflow automation tooling.",
+    "rationale": "Validations 04a/04b and audits 05a/05b proved that Phase 3 embedded workflow metadata in product endpoints and Phase 4 depends on that shared module. Remediation must occur before declaring the workflow track complete or advancing Executor MVP Gate G3.",
+    "references": [
+      "docs/05_151024_todays_status.md/03_phase1-p4_WF_validation_checklist.md",
+      "docs/05_151024_todays_status.md/04a_validation_&_remediation_WF.md",
+      "docs/05_151024_todays_status.md/04b_validation_&_remediation_WF.md",
+      "docs/05_151024_todays_status.md/05a_Audit_of_validation_and_remediation.md",
+      "docs/05_151024_todays_status.md/05b_Audit_of_validation_and_remediation.md",
+      "docs/05_151024_todays_status.md/06_final_validation_and_remediation_summary.md",
+      "WHAT_IS_WHAT.md"
+    ]
+  },
+  "project": {
+    "name": "Autonomous Workflow System",
+    "current_phase": "Workflow Phase 1-4 Remediation",
+    "goal": "Eliminate workflow metadata exposure from product code, isolate workflow libraries, capture validation evidence, and certify workflow automation readiness.",
+    "scope": "Server decoupling, module relocation, contract evidence persistence, workflow CLI test coverage, and validation gate execution.",
+    "estimated_time": "3-4 engineering days including validation and audits",
+    "work_profile": "TypeScript/JavaScript remediation, Express server cleanup, contract tooling maintenance, Vitest updates",
+    "out_of_scope": [
+      "New product features",
+      "LangGraph orchestrator enhancements",
+      "UI consumption of workflow metadata"
+    ]
+  },
+  "execution_model": {
+    "type": "autonomous_with_verification",
+    "verification_strategy": "halt_on_contamination_detected",
+    "description": "Confirm contamination baseline, remove workflow coupling step-by-step, rerun validations after each win, and document evidence in contracts and .automation logs.",
+    "failure_mode": "halt_and_report_with_diff",
+    "no_assumptions": true,
+    "evidence_required": true
+  },
+  "stack_compliance": {
+    "enforced_by": "ai-stack.json + AGENTS.md",
+    "language": "TypeScript/JavaScript",
+    "frameworks": [
+      "Vitest"
+    ],
+    "test_command": "npm test",
+    "constraints": [
+      "No Python files",
+      "No new npm dependencies without owner approval",
+      "Coverage ≥ 80% line / 75% branch",
+      "ESLint warnings forbidden"
+    ],
+    "validation": "npm run contract:check"
+  },
+  "environments": {
+    "dev": {
+      "node_version": ">=20.10.0 <21",
+      "package_manager": "npm",
+      "os": "linux|macos",
+      "verify_commands": [
+        "node -v",
+        "npm -v",
+        "npm run state:show"
+      ]
+    }
+  },
+  "observability": {
+    "description": "Track remediation progress, validation runs, and evidence capture for audit readiness.",
+    "trace_file": ".automation/workflow_phase1-4_remediation_trace.jsonl",
+    "discovery_file": ".automation/workflow_phase1-4_remediation_discovery.json",
+    "evidence_file": ".automation/workflow_phase1-4_remediation_evidence.json",
+    "evaluation_file": ".automation/workflow_phase1-4_remediation_evaluation.json",
+    "monitoring": {
+      "task_status_tracking": true,
+      "verification_pass_fail": true,
+      "elapsed_time_per_task": true
+    },
+    "logging": {
+      "format": "jsonl",
+      "fields": [
+        "timestamp",
+        "task_id",
+        "action",
+        "status",
+        "cmd",
+        "exit_code",
+        "stdout_excerpt",
+        "stderr_excerpt"
+      ]
+    },
+    "evaluation": {
+      "continuous": true,
+      "evaluate_after_each_win": true,
+      "quality_dimensions": [
+        "correctness",
+        "completeness",
+        "safety"
+      ]
+    }
+  },
+  "global_quality_standards": {
+    "lint": {
+      "command": "npm run lint",
+      "must_pass": true,
+      "max_warnings": 0
+    },
+    "typecheck": {
+      "command": "npm run typecheck",
+      "must_pass": true
+    },
+    "tests": {
+      "command": "npm test",
+      "expected": {
+        "exit_code": 0,
+        "no_failed_suites": true
+      },
+      "coverage": {
+        "min_line_pct": 80,
+        "min_branch_pct": 75
+      }
+    },
+    "schemas": {
+      "ajv_strict": true,
+      "draft_version": "2020-12"
+    }
+  },
+  "high_level_stages": [
+    "prerequisite_verification",
+    "runtime_decoupling",
+    "workflow_isolation",
+    "evidence_capture",
+    "validation_gate"
+  ],
+  "tasks": [
+    {
+      "id": "WF5-V01",
+      "stage": "prerequisite_verification",
+      "title": "Confirm contamination baseline",
+      "type": "verification",
+      "description": "Reproduce current contamination signals before making changes to guarantee remediation addresses the verified state.",
+      "time_estimate_minutes": 45,
+      "actions": [
+        {
+          "type": "observe",
+          "cmd": "rg --line-number 'workflowMetadata' src/server.ts",
+          "capture_output": true
+        },
+        {
+          "type": "observe",
+          "cmd": "grep -n '/api/workflow/status' src/server.ts",
+          "capture_output": true
+        },
+        {
+          "type": "observe",
+          "cmd": "npm test -- tests/api/workflow-status.test.ts",
+          "expect_exit_code": 0,
+          "capture_output": true
+        }
+      ],
+      "success_criteria": [
+        "Existing contamination confirmed and documented",
+        "Baseline test exercising contaminated endpoint captured"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_baseline_verification",
+        "reasoning_required": true
+      }
+    },
+    {
+      "id": "WF5-W51",
+      "stage": "runtime_decoupling",
+      "title": "Remove workflow metadata from product runtime",
+      "type": "win",
+      "description": "Delete workflow imports, metadata cache, and `/api/workflow/status` route from `src/server.ts`; ensure progress payloads contain only product data.",
+      "time_estimate_minutes": 240,
+      "actions": [
+        {
+          "type": "edit",
+          "file": "src/server.ts",
+          "content_spec": "Remove workflow helper imports, metadata cache logic, workflowMetadata fields, and `/api/workflow/status` registration."
+        }
+      ],
+      "validation": [
+        {
+          "cmd": "rg --line-number 'workflowMetadata' src/server.ts",
+          "expect_exit_code": 1
+        },
+        {
+          "cmd": "rg '/api/workflow/status' src/server.ts",
+          "expect_exit_code": 1
+        },
+        {
+          "cmd": "npm test -- tests/api/workflow-status.test.ts",
+          "expect_exit_code": 1,
+          "allow_failure_note": "Test should fail because endpoint removed; will be deleted in WF5-W54."
+        }
+      ],
+      "success_criteria": [
+        "Server no longer references workflow helpers",
+        "Progress payloads exclude workflow metadata",
+        "Workflow endpoint removed"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_runtime_decoupling",
+        "win_number": "51"
+      }
+    },
+    {
+      "id": "WF5-W52",
+      "stage": "workflow_isolation",
+      "title": "Isolate workflow state module",
+      "type": "win",
+      "description": "Relocate workflow state implementation outside `src/`, update CLI imports, and add optional workflow-specific TypeScript config to prevent regressions.",
+      "time_estimate_minutes": 210,
+      "actions": [
+        {
+          "type": "move",
+          "from": "src/state/phaseState.ts",
+          "to": "workflow/lib/phaseState.ts"
+        },
+        {
+          "type": "edit",
+          "file": "scripts/snapshot-state.js",
+          "content_spec": "Update imports to new workflow module path."
+        },
+        {
+          "type": "edit",
+          "file": "scripts/sync-contract-status.js",
+          "content_spec": "Update imports to new workflow module path."
+        },
+        {
+          "type": "edit",
+          "file": "scripts/execute-next-action.js",
+          "content_spec": "Update imports to new workflow module path."
+        },
+        {
+          "type": "create_file",
+          "file": "tsconfig.workflow.json",
+          "content_spec": "Optional TypeScript configuration isolating workflow tooling build."
+        }
+      ],
+      "validation": [
+        {
+          "cmd": "test -f workflow/lib/phaseState.ts",
+          "expect_exit_code": 0
+        },
+        {
+          "cmd": "rg 'from \\"./state/phaseState\\"' -g'*.ts'",
+          "expect_exit_code": 1
+        },
+        {
+          "cmd": "npm test -- tests/state/phaseState.test.ts",
+          "expect_exit_code": 0
+        }
+      ],
+      "success_criteria": [
+        "Workflow module resides outside product source tree",
+        "CLI scripts compile with new path",
+        "Optional workflow tsconfig documented"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_workflow_isolation",
+        "win_number": "52"
+      }
+    },
+    {
+      "id": "WF5-W53",
+      "stage": "evidence_capture",
+      "title": "Persist contract validation evidence",
+      "type": "win",
+      "description": "Enhance contract sync tooling to populate `validation_results`, update tests to assert evidence presence, and re-run sync to refresh contract files.",
+      "time_estimate_minutes": 180,
+      "actions": [
+        {
+          "type": "edit",
+          "file": "scripts/sync-contract-status.js",
+          "content_spec": "Capture command outputs and write them to validation_results before marking tasks complete."
+        },
+        {
+          "type": "edit",
+          "file": "tests/state/sync.test.ts",
+          "content_spec": "Assert validation_results arrays are populated for completed tasks."
+        }
+      ],
+      "validation": [
+        {
+          "cmd": "npm test -- tests/state/sync.test.ts",
+          "expect_exit_code": 0
+        },
+        {
+          "cmd": "npm run state:sync",
+          "expect_exit_code": 0
+        },
+        {
+          "cmd": "rg 'validation_results' contracts/Roadmap_execution/19_phase19_autonomous_transition_contract.json",
+          "expect_exit_code": 0
+        }
+      ],
+      "success_criteria": [
+        "Sync script writes validation evidence",
+        "Tests enforce evidence presence",
+        "Contract warnings cleared"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_evidence_capture",
+        "win_number": "53"
+      }
+    },
+    {
+      "id": "WF5-W54",
+      "stage": "evidence_capture",
+      "title": "Retire contaminated API test & reinforce CLI coverage",
+      "type": "win",
+      "description": "Remove workflow-status API test, add or update CLI-level tests to verify workflow tooling remains functional post-isolation.",
+      "time_estimate_minutes": 120,
+      "actions": [
+        {
+          "type": "delete",
+          "file": "tests/api/workflow-status.test.ts"
+        },
+        {
+          "type": "edit",
+          "file": "tests/state/execute-next-action.test.ts",
+          "content_spec": "Update imports/assertions to reflect relocated workflow module and absence of workflow metadata in product payloads."
+        }
+      ],
+      "validation": [
+        {
+          "cmd": "test -f tests/api/workflow-status.test.ts",
+          "expect_exit_code": 1
+        },
+        {
+          "cmd": "npm test -- tests/state/execute-next-action.test.ts",
+          "expect_exit_code": 0
+        }
+      ],
+      "success_criteria": [
+        "Contaminated API test removed",
+        "Workflow CLI coverage intact",
+        "Test suite reflects new boundaries"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_cli_validation",
+        "win_number": "54"
+      }
+    },
+    {
+      "id": "WF5-GATE",
+      "stage": "validation_gate",
+      "title": "Workflow remediation validation gate",
+      "type": "validation",
+      "description": "Run full validation checklist to certify remediation, capture evidence, and prepare summary report before unblocking Executor MVP Gate G3.",
+      "time_estimate_minutes": 180,
+      "actions": [
+        {
+          "type": "validate",
+          "cmd": "npm run lint"
+        },
+        {
+          "type": "validate",
+          "cmd": "npm run typecheck"
+        },
+        {
+          "type": "validate",
+          "cmd": "npm test"
+        },
+        {
+          "type": "validate",
+          "cmd": "npm run contract:check"
+        },
+        {
+          "type": "validate",
+          "cmd": "npm run sbom:all"
+        },
+        {
+          "type": "validate",
+          "cmd": "npm run provenance"
+        },
+        {
+          "type": "manual_validate",
+          "description": "Run npm run state:show, npm run state:sync, and npm run state:next:dry to confirm workflow tooling functions without product coupling."
+        }
+      ],
+      "success_criteria": [
+        "All validations succeed with zero warnings",
+        "No workflow metadata present in product server",
+        "Contract warnings resolved",
+        "Remediation summary recorded in docs"
+      ],
+      "trace_context": {
+        "decision_point": "wf5_validation_gate",
+        "critical": true,
+        "gate_type": "go_no_go"
+      }
+    }
+  ],
+  "execution_order": [
+    "WF5-V01",
+    "WF5-W51",
+    "WF5-W52",
+    "WF5-W53",
+    "WF5-W54",
+    "WF5-GATE"
+  ],
+  "execution_semantics": {
+    "win_isolation": {
+      "description": "Do not proceed to evidence capture until runtime decoupling and workflow isolation passes lint/typecheck/tests.",
+      "implementation": "After WF5-W51 and WF5-W52, run npm run lint && npm run typecheck before moving to WF5-W53."
+    },
+    "gate_enforcement": {
+      "WF5-GATE": {
+        "required": true,
+        "on_fail": "Halt, revert partial changes if necessary, and document remediation blockers in .automation/workflow_phase1-4_remediation_evaluation.json",
+        "report": "Provide summary, failing command output, and next steps."
+      }
+    },
+    "phase_specific_constraints": {
+      "no_public_workflow_endpoints": "New product endpoints must not expose workflow metadata.",
+      "cli_only_workflow_state": "Workflow state access limited to CLI/tools outside src/."
+    }
+  },
+  "completion_criteria": {
+    "workflow_metadata_removed": true,
+    "workflow_module_isolated": true,
+    "contract_evidence_populated": true,
+    "contaminated_tests_removed": true,
+    "all_validations_pass": true,
+    "audit_trail_updated": true
+  },
+  "fallback_policies": {
+    "validation_failure": "Stop immediately, capture logs, and create remediation note before retrying.",
+    "unexpected_dependency": "Escalate to repository owner; do not add dependencies without approval.",
+    "cli_regression": "Re-run npm test for workflow CLI suites; if failures persist, revert to last known good commit."
+  },
+  "reporting": {
+    "progress_file": ".automation/workflow_phase1-4_remediation_progress.json",
+    "fields": [
+      "task_id",
+      "status",
+      "started_at",
+      "completed_at",
+      "elapsed_ms",
+      "notes"
+    ],
+    "status_values": [
+      "pending",
+      "running",
+      "succeeded",
+      "blocked"
+    ],
+    "phase_report": {
+      "file": ".automation/workflow_phase1-4_remediation_completion.json",
+      "fields": [
+        "wins_completed",
+        "gate_passed",
+        "timestamp",
+        "evidence_bundle_paths"
+      ]
+    }
+  },
+  "final_artifacts_verification": [
+    {
+      "name": "Server decoupling",
+      "path": "src/server.ts",
+      "must_not_include_regex": "workflowMetadata"
+    },
+    {
+      "name": "Workflow module location",
+      "path": "workflow/lib/phaseState.ts",
+      "must_include_regex": "export"
+    },
+    {
+      "name": "Contract evidence",
+      "path": "contracts/Roadmap_execution/19_phase19_autonomous_transition_contract.json",
+      "must_include_regex": "validation_results"
+    }
+  ]
+}

--- a/docs/05_151024_todays_status.md/01_current_assesment.md
+++ b/docs/05_151024_todays_status.md/01_current_assesment.md
@@ -1,159 +1,51 @@
 CURRENT STATUS ASSESSMENT
+
 🎯 Executive Summary
-Phase: Phase 19/20 - Autonomous Transition (Trust Spine + LangGraph Foundation)
-Overall Status: 🟢 STRONG - All critical milestones complete, minor test flakiness detected
-Last Major Achievement: Trust Spine (G2) PASSED, Documentation clarity established
+Phase: Workflow Track — Phases 1-4 validation & remediation alignment
+Overall Status: 🔴 BLOCKED – Track contamination confirmed in Phase 3 deliverables; remediation contract required before G3 work proceeds.
+Last Major Achievement: Dual independent validations (04a & 04b) plus audits concurred on contamination root cause and remediation priorities.
+
 📦 PRODUCT TRACK: Executor MVP
-✅ Phase 19 T0 - Trust Spine: COMPLETE
-Gate G2: ✅ PASSED (2025-10-13) Implemented Features:
-✅ CycloneDX 1.6 SBOM - 1.7 MB, 680 components tracked
-✅ SLSA v1.0 Provenance - 71 artifacts attested
-✅ OpenTelemetry GenAI - Full instrumentation with semantic conventions
-✅ JSONL Action Logs - SIEM-compatible audit trail
-✅ RFC 9457 Problem Details - Standardized HTTP errors with corrections
-Evidence Bundle: 5/5 files in .automation/evidence/G2/ Quality Metrics:
-Tests: 355 passing, 1 flaky (99.7% pass rate)
-Coverage: 82.18% line, 78.24% branch (exceeds 80%/75% thresholds)
-Linting: ✅ 0 errors, 0 warnings
-Type Checking: ✅ 0 errors
-🟡 Phase 20 M1 - LangGraph Pilot: PARTIAL
-Gate G3: 🟡 PARTIAL (Infrastructure complete, integration pending) Completed:
-✅ Executions store (src/orchestrator/executionsStore.ts)
-✅ GET /api/executions/:id endpoint functional
-✅ Adapter pattern with feature flags (AGENTS_RUNTIME=langgraph|stepqueue)
-✅ Graph orchestrator scaffold (src/orchestrator/graph.ts)
-✅ Tests: tests/api/executions.test.ts passing
-Pending for G3 Completion:
-⏳ POST /api/execute LangGraph integration
-⏳ Deterministic replay validation
-⏳ Performance benchmarks (target: < 500ms overhead)
-⏳ Parity tests (StepQueue vs LangGraph output comparison)
-⏳ Coverage validation (target: ≥ 90% for orchestrator)
-Estimated Effort: 6-8 hours
-⏳ Gate G4 - HITL + MCP: NOT STARTED
-Status: Future milestone (Phase 19 U1) Requirements:
-HITL approvals in UI/WebSocket stream
-MCP tools with allow-list policy
-Tool call audit trail in SIEM feed
-ASVS/LLM-Top10 compliance
+✅ Phase 19 T0 – Trust Spine: COMPLETE (unchanged)
+🟡 Phase 20 M1 – LangGraph Pilot (G3): PARTIAL and on hold pending workflow remediation
+• Blocker: Product runtime currently imports workflow helpers and exposes developer metadata; remediation must land before parity/perf work resumes.
+
 🔄 WORKFLOW TRACK: Developer Progression System
-✅ Phase 1 - State Snapshot: COMPLETE
-✅ npm run state:show - Generates WHERE_AM_I.json
-✅ Synthesizes gates, contracts, git status
-✅ Human-readable summary included
-✅ Phase 2 - Contract Sync: COMPLETE
-✅ npm run state:sync - Updates contract task statuses
-✅ Evidence-based validation (regenerates SBOM/provenance, checks files)
-✅ Last sync: 2025-10-14, contract not stale
-⏳ Phase 3 - Orchestrator Integration: PENDING
-Status: Scaffold exists, not wired into runtime What Exists:
-✅ src/state/phaseState.ts - TypeScript module with loadPhaseState(), suggestNextAction(), formatHumanSummary()
-✅ Type definitions for PhaseState, ValidationSnapshot, NextAction
-What's Needed:
-⏳ Wire phaseState.ts into src/server.ts progress endpoints
-⏳ Add endpoint: GET /api/workflow/status (returns current phase state)
-⏳ Integrate with SSE progress streams
-⏳ Add tests for workflow state endpoints
-Estimated Effort: 2-3 hours
-⏳ Phase 4 - Autonomous Executor: PENDING
-Status: Not started Requirements:
-⏳ Create scripts/execute-next-action.js
-⏳ Dry-run support (--dry-run flag)
-⏳ Action execution based on suggestNextAction()
-⏳ Safety checks (no auto-push, human approval for breaking changes)
-Estimated Effort: 2-3 hours
-📚 DOCUMENTATION STATUS
-✅ New Documentation Created
-✅ WHAT_IS_WHAT.md (18 KB) - Category clarification guide
-Separates product features from workflow tools
-Includes "Similar Words, Different Meanings" table
-Decision guide for "Should I work on X?"
-Current status of both parallel tracks
-✅ Documentation Updated
-✅ README.md - Added WHAT_IS_WHAT.md reference in Quick Navigation
-✅ GATES_LEDGER.md - G2 marked PASSED with full evidence
-✅ CDI_INFRASTRUCTURE.md - Trust Spine status markers updated
-✅ AGENTS.md - Phase 19 requirements documented
-⚠️ ISSUES DETECTED
-🐛 Test Flakiness (Low Priority)
-Status: 1-2 tests fail intermittently (race condition suspected) Failing Tests:
-tests/api/execute-with-clarifications.test.ts - "uses augmented prompt when clarifications provided"
-tests/api/execute-with-planning.test.ts - "keeps existing flow for simple prompts"
-Impact: Minor - 99.7% pass rate, tests pass on retry Root Cause Hypothesis: Async timing issues in test setup/teardown, possible mock state leakage Recommendation: Address before G3 completion (track as technical debt for now)
-🎯 NEXT STEP SUGGESTIONS
-Based on the recommendation in WHAT_IS_WHAT.md:
-"Finish WORKFLOW Phases 3-4, THEN advance PRODUCT G3"
-Option A: Complete Workflow Infrastructure (RECOMMENDED)
-Why: Solves the core problem ("what's next?" confusion), small investment (5-6 hours) for permanent clarity Tasks:
-Phase 3 Integration (2-3 hours)
-Wire src/state/phaseState.ts into src/server.ts
-Add GET /api/workflow/status endpoint
-Integrate with SSE progress streams
-Write tests for workflow endpoints
-Phase 4 Executor (2-3 hours)
-Create scripts/execute-next-action.js
-Implement dry-run mode
-Add safety checks (no auto-push, human approval gates)
-Write integration tests
-Benefits:
-Autonomous "what's next?" suggestions
-Reduces developer cognitive load
-Makes G3 development smoother
-Prevents category confusion from recurring
-Option B: Advance Product to G3 (Alternative)
-Why: Complete LangGraph pilot, enable multi-agent orchestration Tasks:
-LangGraph Integration (3-4 hours)
-Wire POST /api/execute to use LangGraph adapter
-Implement deterministic replay
-Add Trust Spine telemetry integration
-Validation & Performance (3-4 hours)
-Run parity tests (StepQueue vs LangGraph)
-Measure p50 overhead (target: < 500ms)
-Validate coverage ≥ 90%
-Update GATES_LEDGER to mark G3 as PASSED
-Blockers: None (G2 complete)
-Option C: Fix Test Flakiness (Quick Win)
-Why: Clean up technical debt, ensure 100% test reliability Tasks:
-Investigate async timing in execute-with-clarifications.test.ts
-Add proper mock cleanup in test teardown
-Consider adding test isolation helpers
-Validate all 356 tests pass consistently
-Estimated Effort: 1-2 hours
-🎓 STRATEGIC RECOMMENDATION
-My Recommendation: Option A (Complete Workflow Phases 3-4) Reasoning:
-Addresses Root Problem: The original request was to solve "what did we do, what's next?" confusion
-Small Investment: 5-6 hours vs ongoing confusion cost
-Force Multiplier: Makes all future work (including G3) more efficient
-Prevents Regression: The confusion we experienced during this session demonstrates the need
-Foundation for Autonomy: Enables the autonomous executor vision from the beginning
-After Workflow Complete:
-Fix test flakiness (1-2 hours)
-Advance to G3 with full workflow support (6-8 hours)
-All work self-documenting and trackable
-📊 SUMMARY DASHBOARD
-Track	Component	Status	Completion	Next Step
-PRODUCT	Trust Spine (G2)	✅ Complete	100%	-
-PRODUCT	LangGraph Pilot (G3)	🟡 Partial	60%	Integration + Tests
-PRODUCT	HITL + MCP (G4)	⏳ Not Started	0%	Await G3
-WORKFLOW	Snapshot (Phase 1)	✅ Complete	100%	-
-WORKFLOW	Sync (Phase 2)	✅ Complete	100%	-
-WORKFLOW	Integration (Phase 3)	🟡 Scaffold	40%	Wire into runtime
-WORKFLOW	Executor (Phase 4)	⏳ Not Started	0%	Create script
-QUALITY	Tests	🟡 Flaky	99.7%	Fix race conditions
-DOCS	Clarity	✅ Complete	100%	-
-🚀 IMMEDIATE NEXT ACTION
-If following Option A (my recommendation):
-# Start with Phase 3 Integration
-1. Wire src/state/phaseState.ts into src/server.ts
-2. Add GET /api/workflow/status endpoint
-3. Write tests for new endpoint
-4. Verify with: npm test tests/api/workflow-status.test.ts
-Commands to prepare:
-npm run state:show  # Verify current state
-npm test            # Confirm baseline (355/356 passing)
-npm run lint        # Ensure clean start
-What would you like to prioritize?
-Complete Workflow Phases 3-4 (5-6 hours, addresses core confusion)
-Advance Product to G3 (6-8 hours, enables multi-agent orchestration)
-Fix test flakiness first (1-2 hours, technical debt cleanup)
-Something else?
+✅ Phase 1 – State Snapshot: COMPLETE (CLI-only, validated by both reports)
+✅ Phase 2 – Contract Sync: FUNCTIONALLY COMPLETE but ⚠️ requires evidence capture upgrade (missing validation_results raised to P1 in Validation 04b)
+❌ Phase 3 – Runtime Integration: CONTAMINATED
+• Issues: `src/server.ts` imports workflow helpers, widens product types, caches metadata, and serves `/api/workflow/status` to end users.
+• Impact: Violates `WHAT_IS_WHAT.md` separation; leaks developer-only context to product APIs.
+⚠️ Phase 4 – Autonomous Executor: PARTIAL
+• CLI behaves as designed but depends on contaminated shared module (`src/state/phaseState.ts`). Module relocation + boundary hardening required.
+
+📚 VALIDATION & AUDIT HIGHLIGHTS
+• Validation 04a: Identified three critical contamination issues, supplied actionable rollback steps, but under-scoped evidence gaps.
+• Validation 04b: Superset of 04a findings; adds root-cause module isolation, evidence capture, SBOM/provenance verification, and comprehensive follow-up plan.
+• Audits 05a & 05b: Both auditors endorse 04b as authoritative. Recommendation: adopt 04b remediation scope while borrowing 04a’s issue tracking ergonomics.
+
+⚠️ CRITICAL ISSUES TO REMEDIATE
+1. Remove workflow metadata from product runtime (imports, progress payloads, `/api/workflow/status`).
+2. Relocate workflow state module outside `src/` to restore hard boundaries.
+3. Capture validation evidence into contracts via enhanced sync script.
+4. Retire contaminated API tests; replace with workflow CLI coverage as needed.
+
+🎯 NEXT ACTIONS
+• Execute new remediation contract `05_workflow_phase1-4_remediation_execution_contract.json` (see contracts/Roadmap_workflow/).
+• After remediation, rerun full validation checklist (lint, typecheck, tests, contract:check, SBOM, provenance) to confirm clean separation.
+• Once workflow track passes remediation gate, unblock Executor MVP Gate G3 LangGraph execution work.
+
+📊 STATUS DASHBOARD
+Track   Component                                Status         Next Step
+PRODUCT LangGraph Pilot (G3)                     ⛔ Blocked      Wait for workflow remediation completion
+WORKFLOW Phase 1 Snapshot                        ✅ Complete     Monitor for regressions
+WORKFLOW Phase 2 Contract Sync                   ⚠️ Partial      Implement evidence capture updates
+WORKFLOW Phase 3 Runtime Integration             ❌ Contaminated Remove workflow coupling from server/tests
+WORKFLOW Phase 4 Autonomous Executor             ⚠️ Partial      Rewire to relocated workflow module post-cleanup
+GOVERNANCE Validation/Audit Alignment            ✅ Complete     Use Validation 04b + Audit guidance as source of truth
+
+🚀 IMMEDIATE ORDER OF OPERATIONS
+1. Approve & execute remediation contract tasks (P0 → P1 → P2 priority sequence).
+2. Verify contamination removal with fresh validation reports + contract evidence.
+3. Update GATES_LEDGER and roadmap checkpoints only after remediation gate passes.
+4. Resume Executor MVP G3 work once workflow track confirmed clean.

--- a/docs/05_151024_todays_status.md/02_WF_p1-p4_completion_report.md
+++ b/docs/05_151024_todays_status.md/02_WF_p1-p4_completion_report.md
@@ -1,176 +1,45 @@
-Implementation Complete!
-✅ What Was Accomplished
-I successfully completed the autonomous workflow system integration, implementing Phase 3: Orchestrator Integration and Phase 4: Autonomous Executor.
-📦 Phase 3: Orchestrator Integration
-New API Endpoint
-Added: GET /api/workflow/status endpoint at src/server.ts:2305-2319
-Purpose: Exposes workflow metadata (phase, gates, tasks, suggested actions) via REST API
-Returns: Complete WorkflowMetadata structure with:
-Current phase and gate status
-Task list with completion state
-Suggested next action with reasoning
-Uncommitted changes count
-Human-readable summary
-Enhanced Progress Tracking
-Modified: Progress snapshots already included workflow metadata (lines 137, 292, 303, 370, 381)
-Benefit: SSE streams and polling endpoints now automatically include workflow context
-Impact: Real-time workflow visibility for both UI and API consumers
-Tests Created
-File: tests/api/workflow-status.test.ts
-Coverage: 11 comprehensive tests validating:
-Phase and gate information
-Current/next task identification
-Suggested action generation
-Validation snapshot inclusion
-Human-readable summary
-Error handling
-🤖 Phase 4: Autonomous Executor
-Autonomous Action Script
-File: scripts/execute-next-action.js
-Features:
-Dry-run mode (--dry-run): Preview actions without executing
-Interactive mode (--interactive, default): Ask for confirmation
-Auto mode (--auto): Execute without confirmation (use with caution)
-Safety checks: Blocks git push, npm publish, rm -rf, and other destructive operations
-Rich output: Emoji-enhanced formatting with clear status indicators
-npm Commands Added
-npm run state:next          # Interactive execution (asks for confirmation)
-npm run state:next:auto     # Automatic execution (no confirmation)
-npm run state:next:dry      # Dry-run mode (show what would execute)
-Example Output
-🤖 Autonomous Next Action Executor
+WORKFLOW PHASES 1-4 STATUS REPORT (VALIDATION HOLD)
 
-Loading workflow state...
+## Summary
+The originally claimed completion of Workflow Phases 3-4 is **rejected**. Two independent validations (04a & 04b) plus audits (05a & 05b) confirm that Phase 3 introduced severe track contamination by embedding workflow metadata inside the Executor MVP runtime. Phase 4’s automation relies on that contaminated boundary. Workflow track remains **incomplete** until remediation is executed.
 
-📊 Current State:
-Phase: Autonomous Transition — Trust Spine & LangGraph Foundation
-Current Gate: G3 (partial)
-Current Task: None
-Uncommitted Changes: 15
+## Validation Outcomes
+- **Phase 1 – Snapshot CLI:** ✅ Verified compliant. CLI-only tool, no runtime coupling.
+- **Phase 2 – Contract Sync:** ⚠️ Functionally complete but missing persisted `validation_results`; remediation required to satisfy contract evidence standards.
+- **Phase 3 – Runtime Integration:** ❌ Non-compliant. Product server imports workflow helpers, caches developer metadata, and exposes `/api/workflow/status`.
+- **Phase 4 – Autonomous Executor:** ⚠️ Partial. CLI behaves correctly but depends on contaminated module within `src/`.
 
-🎯 Suggested Next Action:
-Action: COMMIT_PENDING_TESTS
-Reasoning: Uncommitted changes detected. Commit to persist progress.
-Command: git add -A && git commit -m 'chore: persist progress'
+## Key Evidence
+- `docs/05_151024_todays_status.md/04a_validation_&_remediation_WF.md`
+- `docs/05_151024_todays_status.md/04b_validation_&_remediation_WF.md`
+- `docs/05_151024_todays_status.md/05a_Audit_of_validation_and_remediation.md`
+- `docs/05_151024_todays_status.md/05b_Audit_of_validation_and_remediation.md`
+- `docs/05_151024_todays_status.md/06_final_validation_and_remediation_summary.md`
 
-[DRY RUN MODE]
-Would execute: git add -A && git commit -m 'chore: persist progress'
+## Remediation Directives (adopted from Validation 04b + audit guidance)
+1. **Remove workflow metadata from product runtime**
+   - Delete workflow imports/metadata cache from `src/server.ts`.
+   - Remove `workflowMetadata` from progress payloads.
+   - Eliminate `/api/workflow/status` endpoint.
+2. **Isolate workflow module**
+   - Relocate `src/state/phaseState.ts` outside product source tree.
+   - Update CLI scripts to import from the new workflow library location.
+   - Optionally introduce separate workflow TypeScript config to prevent regressions.
+3. **Capture validation evidence**
+   - Enhance `scripts/sync-contract-status.js` to persist command outputs into `validation_results`.
+   - Extend tests to assert evidence presence.
+4. **Retire contaminated API tests**
+   - Remove `tests/api/workflow-status.test.ts` (after endpoint removal).
+   - Replace with CLI-focused coverage if necessary.
 
-To execute, run: npm run state:next
-Tests Created
-File: tests/state/execute-next-action.test.ts
-Coverage: 16 comprehensive tests validating:
-Help display
-Dry-run mode
-Workflow state display
-Action suggestion
-NO_ACTION handling
-Safety checks
-Command-line flags
-Error handling
-📚 Documentation Updates
-WHAT_IS_WHAT.md
-✅ Marked Phases 3-4 as COMPLETE
-✅ Updated workflow commands list
-✅ Added new script to key files section
-✅ Updated current status and recommendations
-✅ Added status column to decision guide table
-README.md
-✅ Added "Workflow State Management (Autonomous System)" section
-✅ Documented all workflow commands with descriptions
-CLAUDE.md
-✅ Added "Workflow State Management (Autonomous System)" section
-✅ Documented workflow commands in Commands section
-✅ Aligned with README.md structure
-✅ Quality Validation
-All Checks Passing
-✅ npm run lint          # 0 errors, 0 warnings
-✅ npm run typecheck     # 0 errors
-✅ npm test              # 383 tests passing (367→383, +16 new tests)
-✅ npm run contract:check # All 8 contracts valid
-✅ Coverage: 82.18% line, 78.24% branch (exceeds thresholds)
-Test Count Evolution
-Before: 367 tests passing
-After: 383 tests passing
-New Tests:
-11 workflow-status endpoint tests
-16 execute-next-action script tests
-Total: 27 new tests added
-🎯 Benefits Delivered
-For Developers
-No More "What's Next?" Confusion
-Run npm run state:show to see current status
-Run npm run state:next:dry to see suggested action
-Clear guidance at every step
-Autonomous Action Execution
-Safe, interactive execution of workflow suggestions
-Dry-run mode for validation
-Built-in safety checks prevent destructive operations
-Real-Time Workflow Visibility
-API endpoint exposes workflow state
-SSE streams include workflow metadata
-UI can show "where am I?" alongside execution progress
-For the System
-Single Source of Truth
-All workflow decisions come from phaseState.ts
-No duplication between CLI and runtime
-Consistent behavior across all interfaces
-Audit Trail
-All actions logged
-Command execution tracked
-Safety violations recorded
-Foundation for Full Autonomy
-Phase 3 provides the infrastructure
-Phase 4 enables safe autonomous actions
-Ready for future AI-driven development
-📁 Files Modified
-New Files Created (3)
-src/server.ts - Added /api/workflow/status endpoint
-scripts/execute-next-action.js - Autonomous executor script
-tests/api/workflow-status.test.ts - Endpoint tests
-tests/state/execute-next-action.test.ts - Script tests
-Files Updated (4)
-package.json - Added 3 new npm commands
-WHAT_IS_WHAT.md - Updated status and recommendations
-README.md - Added workflow commands section
-CLAUDE.md - Added workflow commands section
-Total Changes
-7 files modified
-2 scripts created
-2 test files created
-27 tests added
-3 npm commands added
-1 API endpoint added
-🚀 What's Next?
-Per the updated WHAT_IS_WHAT.md, the recommended next step is: → Advance PRODUCT G3 (LangGraph Orchestrator Pilot)
-Implement LangGraph parity tests
-Measure p50 overhead (target: < 500ms)
-Validate coverage ≥ 90%
-Update GATES_LEDGER to mark G3 as PASSED
-Why This Sequence?
-✅ WORKFLOW track now COMPLETE (Phases 1-4)
-✅ Trust Spine complete (G2 PASSED)
-✅ Workflow automation in place
-⏳ G3 ready to advance with full workflow support
-🎓 Key Learnings
-Progressive Enhancement: Phase 3 built on existing infrastructure (workflow metadata was already partially integrated)
-Safety First: Phase 4 implements multiple safety layers (interactive confirmation, destructive command blocking, dry-run mode)
-Developer Experience: Rich, emoji-enhanced output makes the autonomous system friendly and approachable
-Test Coverage: Comprehensive tests ensure reliability and prevent regression
-📊 Metrics
-Metric	Before	After	Change
-Tests	367	383	+16
-API Endpoints	N/A	1	+1
-npm Commands	34	37	+3
-Scripts	6	8	+2
-Workflow Phases Complete	2/4	4/4	+2
-Coverage	82.18%	82.18%	Maintained
-Lint Errors	0	0	Clean
-Type Errors	0	0	Clean
-✨ Summary
-The autonomous workflow system is now fully operational. Developers and AI agents can:
-See the current state (npm run state:show)
-Sync contract statuses (npm run state:sync)
-Preview next actions (npm run state:next:dry)
-Execute actions autonomously (npm run state:next)
-This eliminates the "what's next?" confusion and provides a solid foundation for future autonomous development capabilities. The system is production-ready, fully tested, and documented. Total Time: ~5 hours (as estimated) Quality: All validation gates passing Status: ✅ READY FOR PRODUCTION
+## Contract Action
+A CDI remediation contract (`contracts/Roadmap_workflow/05_workflow_phase1-4_remediation_execution_contract.json`) has been drafted to govern the above corrective work. Phase 3/4 remain at **HOLD** status until the contract’s gate passes.
+
+## Next Steps
+1. Approve and execute the remediation contract (P0 items before any additional workflow or product work).
+2. Re-run the full validation checklist post-remediation and capture evidence in contracts and `.automation/`.
+3. Publish updated validation & remediation reports confirming contamination removal.
+4. Only after successful remediation, update completion status for Workflow Phases 3-4 and unblock Executor MVP Gate G3 progression.
+
+## Governance Note
+Do **not** expose workflow metadata through product endpoints or shared modules going forward. All workflow automation must live in dedicated workflow tooling (scripts/ or workflow/ directories) with explicit boundaries documented in `WHAT_IS_WHAT.md`.

--- a/docs/05_151024_todays_status.md/06_final_validation_and_remediation_summary.md
+++ b/docs/05_151024_todays_status.md/06_final_validation_and_remediation_summary.md
@@ -1,249 +1,67 @@
-I'll help you review these validation and audit documents. Let me start by reading all the files.I've thoroughly reviewed all the validation and audit documents. Let me provide you with a comprehensive assessment and a concise remediation plan.
+# Final Validation & Remediation Summary — Workflow Phases 1-4
 
-## Comprehensive Assessment
+## 1. Scope & Method
+- Reviewed the official validation checklist (`03_phase1-p4_WF_validation_checklist.md`).
+- Consumed both validator submissions (`04a_validation_&_remediation_WF.md`, `04b_validation_&_remediation_WF.md`).
+- Reviewed both independent audits (`05a_Audit_of_validation_and_remediation.md`, `05b_Audit_of_validation_and_remediation.md`).
+- Cross-referenced findings with `WHAT_IS_WHAT.md` governance and runtime code locations (`src/server.ts`, `src/state/phaseState.ts`, `tests/api/workflow-status.test.ts`).
 
-### Executive Summary
+## 2. Consolidated Findings
+| Phase | Outcome | Evidence Highlights |
+|-------|---------|--------------------|
+| Phase 1 – Snapshot CLI | ✅ Compliant | CLI implementation isolated to `scripts/`, verified by both validators. |
+| Phase 2 – Contract Sync | ⚠️ Partial | Functionally correct but missing persisted `validation_results`; flagged as P1 in Validation 04b. |
+| Phase 3 – Runtime Integration | ❌ Contaminated | Product server imports workflow helpers, widens progress payloads, exposes `/api/workflow/status`. |
+| Phase 4 – Autonomous Executor | ⚠️ Partial | CLI works, but relies on contaminated shared module under `src/`. |
 
-**Status: CONTAMINATED** - Both validators and auditors unanimously agree that the Executor MVP repository has critical track contamination issues where Workflow (developer tooling) code has been improperly integrated into the Executor MVP (product) runtime.
+**Track Verdict:** CONTAMINATED. Workflow metadata currently leaks into Executor MVP runtime, violating the separation mandated in `WHAT_IS_WHAT.md` and confirmed by both validations and audits.
 
-**Severity: 🔴 Critical** - This contamination violates the fundamental architectural principle established in `WHAT_IS_WHAT.md` that strictly separates:
-- **Executor MVP** (product for end users generating code)
-- **Autonomous Workflow System** (meta-layer for developers working ON the executor)
+## 3. Validation Comparison & Decision
+- **Validation 04a:** Accurate issue identification (WF3-001/002/003), strong issue tracking, but omits module relocation and contract evidence remediation.
+- **Validation 04b:** Superset of 04a. Adds root-cause module isolation, evidence capture, SBOM/provenance verification, and detailed methodology.
+- **Auditor Consensus:** Both auditors endorse 04b as authoritative and recommend blending 04a’s issue tracking ergonomics.
 
-### Key Findings from Validation Reports
+**Decision:** Adopt Validation 04b as the governing remediation plan, augmenting it with 04a’s ID/checkbox format for task management.
 
-Both validation attempts (04a and 04b) identified the same core contamination but differed in completeness:
+## 4. Approved Remediation Plan (Authoritative Checklist)
+1. **Remove Workflow Metadata from Product Runtime (P0)**
+   - Delete workflow imports, caches, and `workflowMetadata` fields from `src/server.ts`.
+   - Remove `/api/workflow/status` endpoint and associated SSE coupling.
+2. **Isolate Workflow Module (P0)**
+   - Relocate `src/state/phaseState.ts` to a workflow-specific location outside `src/`.
+   - Update workflow CLI scripts to import from the new module path; consider separate `tsconfig.workflow.json`.
+3. **Capture Validation Evidence (P1)**
+   - Enhance `scripts/sync-contract-status.js` to populate `validation_results` before marking tasks complete.
+   - Extend `tests/state/sync.test.ts` to assert evidence persistence; rerun `npm run state:sync`.
+4. **Retire Contaminated API Tests (P2)**
+   - Remove `tests/api/workflow-status.test.ts` once endpoint is gone.
+   - Replace with CLI-level verification if additional coverage needed.
 
-**Validation 04a:**
-- Identified 3 critical contamination issues
-- Provided clear issue tracking with unique IDs (WF3-001, WF3-002, WF3-003)
-- Estimated 7 hours total remediation effort
-- Missed the root cause (shared module coupling)
+## 5. CDI Execution Contract
+A CDI-compliant execution contract has been authored to govern remediation:
+- **File:** `contracts/Roadmap_workflow/05_workflow_phase1-4_remediation_execution_contract.json`
+- **Purpose:** Execute the remediation plan above, capture evidence, and certify workflow track cleanliness before resuming Executor MVP Gate G3 work.
 
-**Validation 04b (Superior):**
-- Identified 4 prioritized issues (P0-P2)
-- Addressed root cause: shared module `src/state/phaseState.ts` serving both tracks
-- Estimated 2.5-4 days total effort (more realistic)
-- Included comprehensive follow-up verification
+## 6. Gate & Roadmap Impact
+- Workflow Phases 3 & 4 remain in **HOLD** status until the new contract’s validation gate passes.
+- Executor MVP Gate G3 (LangGraph Pilot) is **blocked** pending proof of remediation completion.
+- GATES_LEDGER updates must not mark workflow phases complete until remediation evidence is logged.
 
-### Audit Conclusions
+## 7. Required Follow-Up Evidence
+Upon remediation completion, collect and archive:
+- Updated validation report citing clean separation.
+- Command outputs: `npm run lint`, `npm run typecheck`, `npm test`, `npm run contract:check`, `npm run sbom:all`, `npm run provenance`, `npm run state:show`, `npm run state:sync`, `npm run state:next:dry`.
+- Contract sync outputs demonstrating populated `validation_results`.
+- Confirmation that `/api/workflow/status` no longer exists and progress payloads contain product-only data.
 
-Both auditors (05a and 05b) determined **Validation 04b is superior** because it:
-1. Fixes the root cause (module boundary violation)
-2. Elevates missing validation evidence to actionable priority
-3. Provides architectural guidance for clean separation
-4. Includes supply-chain verification (SBOM/provenance)
+## 8. Authorization to Proceed
+The workflow track is **not yet complete**. Execution of `05_workflow_phase1-4_remediation_execution_contract.json` is mandatory before:
+- Declaring Workflow Phase 3 or 4 complete.
+- Advancing Executor MVP Gate G3 LangGraph execution tasks.
 
-### Phase-by-Phase Results
+## 9. Next Coordination Checkpoint
+- Schedule remediation kick-off immediately.
+- Target follow-up review after P0 remediation items land (workflow metadata removal + module isolation).
+- Conduct final validation + audit sign-off before re-opening product roadmap milestones.
 
-| Phase | 04a Verdict | 04b Verdict | Correct Assessment |
-|-------|-------------|-------------|-------------------|
-| Phase 1: Snapshot CLI | ✅ Compliant | ✅ Compliant | ✅ Correct |
-| Phase 2: Contract Sync | ✅ Compliant | ⚠️ Partial | 04b more accurate (missing validation evidence) |
-| Phase 3: Integration | ❌ Contaminated | ❌ Contaminated | Both correct |
-| Phase 4: Autonomous Executor | ✅ Compliant | ⚠️ Partial | 04b more nuanced (depends on contaminated module) |
-
----
-
-## Concise Remediation Plan (1-2 Pages)
-
-### Priority Issues
-
-#### **P0-1: Remove Workflow Metadata from Product Server** 🔴 CRITICAL
-**Location:** `src/server.ts` (lines 85, 124-179, 260-293, 2304-2319)
-
-**Problem:** Product runtime imports workflow state, caches metadata in execution sessions, and exposes developer guidance through end-user APIs.
-
-**Actions:**
-1. Delete workflow imports from `src/server.ts`:
-   - Remove `loadPhaseState`, `buildWorkflowMetadata`, `WorkflowMetadata`
-   - Remove `workflowMetadataCache`, `WorkflowCacheEntry`
-   - Remove `ensureWorkflowMetadataForSession()` helper
-
-2. Refactor `ProgressSnapshot` type:
-   - Remove `workflowMetadata?: WorkflowMetadata` field
-   - Keep only product fields: `stage`, `progress`, `state`
-
-3. Delete `/api/workflow/status` endpoint:
-   - Remove route handler entirely
-   - Document that developers should use `npm run state:show` instead
-
-**Effort:** 1-2 days  
-**Risk:** Medium - Verify no UI dependencies on workflow metadata
-
----
-
-#### **P0-2: Isolate Workflow Module** 🔴 CRITICAL
-**Location:** `src/state/phaseState.ts` (shared between CLI and server)
-
-**Problem:** Workflow library lives under `src/` (product code), allowing accidental imports by product runtime. This is the **root cause** enabling contamination.
-
-**Actions:**
-1. Relocate workflow module:
-   ```bash
-   # Move out of product source tree
-   mkdir -p workflow/lib
-   mv src/state/phaseState.ts workflow/lib/phaseState.ts
-   ```
-
-2. Update all CLI imports:
-   - `scripts/snapshot-state.js`
-   - `scripts/sync-contract-status.js`
-   - `scripts/execute-next-action.js`
-   - Update to: `import { ... } from '../workflow/lib/phaseState.js'`
-
-3. Create TypeScript boundary:
-   ```json
-   // tsconfig.workflow.json
-   {
-     "extends": "./tsconfig.json",
-     "include": ["workflow/**/*", "scripts/**/*"],
-     "exclude": ["src/**/*"]
-   }
-   ```
-
-4. Update build scripts:
-   - Workflow tools build separately from product
-   - Prevents accidental cross-imports
-
-**Effort:** 0.5-1 day  
-**Risk:** Low - Pure refactor, no runtime impact
-
----
-
-#### **P1: Capture Validation Evidence** ⚠️ HIGH
-**Location:** `scripts/sync-contract-status.js`, contract JSON files
-
-**Problem:** Contract tasks marked complete but lack `validation_results` entries, causing validator warnings and weakening audit trail.
-
-**Actions:**
-1. Enhance sync script to capture evidence:
-   ```javascript
-   // In sync-contract-status.js
-   async function completeTask(task) {
-     const result = await executeTaskValidation(task);
-     task.validation_results.push({
-       timestamp: new Date().toISOString(),
-       command: result.command,
-       output: result.output,
-       exitCode: result.exitCode
-     });
-     task.status = "complete";
-     task.completed_at = new Date().toISOString();
-   }
-   ```
-
-2. Update tests to assert evidence presence:
-   ```javascript
-   // In tests/state/sync.test.ts
-   expect(completedTask.validation_results).toBeDefined();
-   expect(completedTask.validation_results.length).toBeGreaterThan(0);
-   ```
-
-**Effort:** 0.5 day  
-**Risk:** Low - Improves auditability
-
----
-
-#### **P2: Remove Contaminated Tests** ⚠️ MEDIUM
-**Location:** `tests/api/workflow-status.test.ts`
-
-**Problem:** API tests enforce the contaminated behavior, preventing cleanup without breaking tests.
-
-**Actions:**
-1. Delete `tests/api/workflow-status.test.ts`
-2. Optionally add workflow CLI test:
-   ```javascript
-   // In tests/state/workflow-cli.test.ts
-   test('state:show outputs workflow metadata', async () => {
-     const result = execSync('npm run state:show --silent');
-     const json = JSON.parse(result.toString());
-     expect(json).toHaveProperty('currentPhase');
-     expect(json).toHaveProperty('gates');
-   });
-   ```
-
-**Effort:** 0.5 day  
-**Risk:** Low - Tests reinstated for CLI
-
----
-
-### Implementation Sequence
-
-1. **Week 1, Day 1-2:** Execute P0-1 (server decoupling)
-   - Branch: `fix/remove-workflow-contamination`
-   - Remove imports, refactor types, delete endpoint
-   - Run full test suite to catch dependencies
-
-2. **Week 1, Day 3:** Execute P0-2 (module isolation)
-   - Move `phaseState.ts` out of `src/`
-   - Update all imports in CLI scripts
-   - Create separate TypeScript config
-
-3. **Week 1, Day 4:** Execute P1 (evidence capture)
-   - Enhance sync script
-   - Add test assertions
-   - Re-run `npm run state:sync`
-
-4. **Week 1, Day 5:** Execute P2 & verification
-   - Remove contaminated tests
-   - Run full validation checklist
-   - Verify `npm run contract:check` passes without warnings
-
----
-
-### Success Criteria
-
-✅ **Track Separation Restored:**
-- Zero imports of workflow code in `src/server.ts`
-- No workflow metadata in `ProgressSnapshot` type
-- No workflow endpoints in product API surface
-
-✅ **Quality Gates Pass:**
-```bash
-npm run lint           # 0 warnings
-npm run typecheck      # 0 errors  
-npm test              # All passing, >80% coverage
-npm run contract:check # No warnings
-```
-
-✅ **Evidence Complete:**
-- All contract tasks have populated `validation_results`
-- SBOM and provenance regenerate successfully
-
----
-
-### Risk Mitigation
-
-**UI Dependency Risk:**
-- Before removing `workflowMetadata`, audit frontend code for usage
-- Add temporary logging if field accessed
-- Communicate changes to frontend team
-
-**Regression Risk:**
-- Run full test suite after each change
-- Maintain feature branch until all verifications pass
-- Consider feature flag for gradual rollout if needed
-
----
-
-### Post-Remediation Verification
-
-Execute complete validation checklist:
-```bash
-npm run state:show
-npm run state:sync  
-npm run state:next:dry
-npm run lint
-npm run typecheck
-npm test -- --coverage
-npm run contract:check
-npm run sbom:all
-npm run provenance
-```
-
-**Expected Results:** All commands succeed, no contamination warnings, contract validator passes cleanly.
-
----
-
-**Bottom Line:** The contamination is fixable in ~4-5 days with proper sequencing. Validation 04b provides the superior blueprint. The key is addressing the **root cause** (shared module boundary) rather than just symptoms, which prevents recurrence and aligns with OWASP API security guidance and SLSA supply-chain best practices.
+**Prepared by:** Governance Reviewer (2025-10-15) — Aligns with CDI standards and auditor recommendations.


### PR DESCRIPTION
## Summary
- replace workflow status assessment documents with auditor-aligned findings that keep phases 3-4 blocked pending remediation
- record the consolidated validation and audit conclusions and call out validation 04b as the authoritative remediation plan
- add a CDI remediation contract to remove workflow contamination, isolate tooling, capture evidence, and run a new validation gate

## Testing
- npm run contract:check


------
https://chatgpt.com/codex/tasks/task_e_68ef8511a3b8832aa80fb205338cebe5